### PR TITLE
153 Fix problem with run-tests in gsw pot-rho-t function, temporary fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ data/*
 
 # Docs
 docs/source/
+glonet_sample.report.ipynb

--- a/assets/glonet_sample.report.ipynb
+++ b/assets/glonet_sample.report.ipynb
@@ -3,19 +3,19 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "8b173ee4",
+   "id": "24a5cb7d",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:26:35.488305Z",
-     "iopub.status.busy": "2025-06-03T08:26:35.488091Z",
-     "iopub.status.idle": "2025-06-03T08:26:36.380291Z",
-     "shell.execute_reply": "2025-06-03T08:26:36.379699Z"
+     "iopub.execute_input": "2025-11-17T11:43:34.146852Z",
+     "iopub.status.busy": "2025-11-17T11:43:34.146450Z",
+     "iopub.status.idle": "2025-11-17T11:43:35.312574Z",
+     "shell.execute_reply": "2025-11-17T11:43:35.311800Z"
     },
     "papermill": {
-     "duration": 0.899313,
-     "end_time": "2025-06-03T08:26:36.381510",
+     "duration": 1.177908,
+     "end_time": "2025-11-17T11:43:35.313025",
      "exception": false,
-     "start_time": "2025-06-03T08:26:35.482197",
+     "start_time": "2025-11-17T11:43:34.135117",
      "status": "completed"
     },
     "tags": []
@@ -40,13 +40,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4855fbb6",
+   "id": "8d6b8b77",
    "metadata": {
     "papermill": {
-     "duration": 0.002833,
-     "end_time": "2025-06-03T08:26:36.387577",
+     "duration": 0.001398,
+     "end_time": "2025-11-17T11:43:35.315998",
      "exception": false,
-     "start_time": "2025-06-03T08:26:36.384744",
+     "start_time": "2025-11-17T11:43:35.314600",
      "status": "completed"
     },
     "tags": []
@@ -60,19 +60,19 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "2e4c9fc4",
+   "id": "fe031471",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:26:36.394357Z",
-     "iopub.status.busy": "2025-06-03T08:26:36.394132Z",
-     "iopub.status.idle": "2025-06-03T08:26:36.682732Z",
-     "shell.execute_reply": "2025-06-03T08:26:36.682100Z"
+     "iopub.execute_input": "2025-11-17T11:43:35.318851Z",
+     "iopub.status.busy": "2025-11-17T11:43:35.318713Z",
+     "iopub.status.idle": "2025-11-17T11:43:35.926317Z",
+     "shell.execute_reply": "2025-11-17T11:43:35.925706Z"
     },
     "papermill": {
-     "duration": 0.293732,
-     "end_time": "2025-06-03T08:26:36.684119",
+     "duration": 0.610028,
+     "end_time": "2025-11-17T11:43:35.926994",
      "exception": false,
-     "start_time": "2025-06-03T08:26:36.390387",
+     "start_time": "2025-11-17T11:43:35.316966",
      "status": "completed"
     },
     "tags": []
@@ -467,13 +467,13 @@
        "    vo                  (first_day_datetime, lead_day_index, depth, lat, lon) float64 3GB dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;\n",
        "    zos                 (first_day_datetime, lead_day_index, lat, lon) float64 155MB dask.array&lt;chunksize=(1, 10, 672, 1440), meta=np.ndarray&gt;\n",
        "Attributes:\n",
-       "    regrid_method:  bilinear</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-76a7d9bb-7509-4937-ba4b-527b82e9bf64' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-76a7d9bb-7509-4937-ba4b-527b82e9bf64' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>first_day_datetime</span>: 2</li><li><span class='xr-has-index'>lead_day_index</span>: 10</li><li><span class='xr-has-index'>depth</span>: 21</li><li><span class='xr-has-index'>lat</span>: 672</li><li><span class='xr-has-index'>lon</span>: 1440</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-be2a0e5a-73c0-49ce-a79e-84db3bf99e84' class='xr-section-summary-in' type='checkbox'  checked><label for='section-be2a0e5a-73c0-49ce-a79e-84db3bf99e84' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>depth</span></div><div class='xr-var-dims'>(depth)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.494 47.37 ... 4.833e+03 5.275e+03</div><input id='attrs-eeedab81-ef4e-4d6f-aa36-9f4e0f389eb4' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-eeedab81-ef4e-4d6f-aa36-9f4e0f389eb4' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-81c1edf7-8ccd-450f-98ae-805546bdbb23' class='xr-var-data-in' type='checkbox'><label for='data-81c1edf7-8ccd-450f-98ae-805546bdbb23' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Depth</dd><dt><span>standard_name :</span></dt><dd>depth</dd><dt><span>units :</span></dt><dd>m</dd><dt><span>units_long :</span></dt><dd>Meters</dd></dl></div><div class='xr-var-data'><pre>array([4.940250e-01, 4.737369e+01, 9.232607e+01, 1.558507e+02, 2.224752e+02,\n",
+       "    regrid_method:  bilinear</pre><div class='xr-wrap' style='display:none'><div class='xr-header'><div class='xr-obj-type'>xarray.Dataset</div></div><ul class='xr-sections'><li class='xr-section-item'><input id='section-3b24a4ef-a908-4fa4-9ca0-91c83331e52e' class='xr-section-summary-in' type='checkbox' disabled ><label for='section-3b24a4ef-a908-4fa4-9ca0-91c83331e52e' class='xr-section-summary'  title='Expand/collapse section'>Dimensions:</label><div class='xr-section-inline-details'><ul class='xr-dim-list'><li><span class='xr-has-index'>first_day_datetime</span>: 2</li><li><span class='xr-has-index'>lead_day_index</span>: 10</li><li><span class='xr-has-index'>depth</span>: 21</li><li><span class='xr-has-index'>lat</span>: 672</li><li><span class='xr-has-index'>lon</span>: 1440</li></ul></div><div class='xr-section-details'></div></li><li class='xr-section-item'><input id='section-4fd06500-2abb-4822-a3f6-1b077bba606b' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4fd06500-2abb-4822-a3f6-1b077bba606b' class='xr-section-summary' >Coordinates: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>depth</span></div><div class='xr-var-dims'>(depth)</div><div class='xr-var-dtype'>float32</div><div class='xr-var-preview xr-preview'>0.494 47.37 ... 4.833e+03 5.275e+03</div><input id='attrs-4b4d5a70-ca81-41e2-a36f-de33738bbae7' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4b4d5a70-ca81-41e2-a36f-de33738bbae7' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-62cab5c3-0ca2-4deb-9c45-26ab0fafa987' class='xr-var-data-in' type='checkbox'><label for='data-62cab5c3-0ca2-4deb-9c45-26ab0fafa987' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>long_name :</span></dt><dd>Depth</dd><dt><span>standard_name :</span></dt><dd>depth</dd><dt><span>units :</span></dt><dd>m</dd><dt><span>units_long :</span></dt><dd>Meters</dd></dl></div><div class='xr-var-data'><pre>array([4.940250e-01, 4.737369e+01, 9.232607e+01, 1.558507e+02, 2.224752e+02,\n",
        "       3.181274e+02, 3.802130e+02, 4.539377e+02, 5.410889e+02, 6.435668e+02,\n",
        "       7.633331e+02, 9.023393e+02, 1.245291e+03, 1.684284e+03, 2.225078e+03,\n",
        "       3.220820e+03, 3.597032e+03, 3.992484e+03, 4.405224e+03, 4.833291e+03,\n",
-       "       5.274784e+03], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-78.0 -77.75 -77.5 ... 89.5 89.75</div><input id='attrs-5b368e88-1154-4d15-8a97-eb31256c4cfd' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-5b368e88-1154-4d15-8a97-eb31256c4cfd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-192777f2-37b8-4422-85b2-b7d8c119d210' class='xr-var-data-in' type='checkbox'><label for='data-192777f2-37b8-4422-85b2-b7d8c119d210' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>units_long :</span></dt><dd>Degrees North</dd></dl></div><div class='xr-var-data'><pre>array([-78.  , -77.75, -77.5 , ...,  89.25,  89.5 ,  89.75], shape=(672,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-180.0 -179.8 ... 179.5 179.8</div><input id='attrs-47a83b02-9f05-4527-9bef-8db82b5b30c9' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-47a83b02-9f05-4527-9bef-8db82b5b30c9' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-44c6b973-5142-4c56-a2e1-643710df17bf' class='xr-var-data-in' type='checkbox'><label for='data-44c6b973-5142-4c56-a2e1-643710df17bf' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>units_long :</span></dt><dd>Degrees East</dd></dl></div><div class='xr-var-data'><pre>array([-180.  , -179.75, -179.5 , ...,  179.25,  179.5 ,  179.75],\n",
-       "      shape=(1440,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lead_day_index</span></div><div class='xr-var-dims'>(lead_day_index)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 6 7 8 9</div><input id='attrs-7388a803-7f93-4be6-9ebf-b790d66a4037' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-7388a803-7f93-4be6-9ebf-b790d66a4037' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-6c5ca71f-1f1d-4b9f-84de-a26272cb04af' class='xr-var-data-in' type='checkbox'><label for='data-6c5ca71f-1f1d-4b9f-84de-a26272cb04af' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>first_day_datetime</span></div><div class='xr-var-dims'>(first_day_datetime)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2024-01-03 2024-01-10</div><input id='attrs-bd54bed4-45a5-48b7-93b2-cef0d53a60cd' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-bd54bed4-45a5-48b7-93b2-cef0d53a60cd' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-bf4e88fa-35bd-414d-88f5-102c02af7759' class='xr-var-data-in' type='checkbox'><label for='data-bf4e88fa-35bd-414d-88f5-102c02af7759' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2024-01-03T00:00:00.000000000&#x27;, &#x27;2024-01-10T00:00:00.000000000&#x27;],\n",
-       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-9457bda4-524a-42c2-90f8-6be56557a868' class='xr-section-summary-in' type='checkbox'  checked><label for='section-9457bda4-524a-42c2-90f8-6be56557a868' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>so</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-336f2b2a-128f-46d8-93cd-dbdfa381933a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-336f2b2a-128f-46d8-93cd-dbdfa381933a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-32fb8e92-c0ad-480d-8076-c1e27801b0b9' class='xr-var-data-in' type='checkbox'><label for='data-32fb8e92-c0ad-480d-8076-c1e27801b0b9' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>sea_water_salinity</dd></dl></div><div class='xr-var-data'><table>\n",
+       "       5.274784e+03], dtype=float32)</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lat</span></div><div class='xr-var-dims'>(lat)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-78.0 -77.75 -77.5 ... 89.5 89.75</div><input id='attrs-3eddb58a-bef4-4c03-9e69-36cd2b7f5d0e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-3eddb58a-bef4-4c03-9e69-36cd2b7f5d0e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-07563dae-5068-4cbc-ac95-0a6a117e1be4' class='xr-var-data-in' type='checkbox'><label for='data-07563dae-5068-4cbc-ac95-0a6a117e1be4' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>Y</dd><dt><span>long_name :</span></dt><dd>Latitude</dd><dt><span>standard_name :</span></dt><dd>latitude</dd><dt><span>units :</span></dt><dd>degrees_north</dd><dt><span>units_long :</span></dt><dd>Degrees North</dd></dl></div><div class='xr-var-data'><pre>array([-78.  , -77.75, -77.5 , ...,  89.25,  89.5 ,  89.75], shape=(672,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lon</span></div><div class='xr-var-dims'>(lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>-180.0 -179.8 ... 179.5 179.8</div><input id='attrs-4191b3d3-f30d-4006-b792-afb9578a932b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-4191b3d3-f30d-4006-b792-afb9578a932b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-33250172-7fd8-4226-82ce-967ad09b7f8a' class='xr-var-data-in' type='checkbox'><label for='data-33250172-7fd8-4226-82ce-967ad09b7f8a' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>axis :</span></dt><dd>X</dd><dt><span>long_name :</span></dt><dd>Longitude</dd><dt><span>standard_name :</span></dt><dd>longitude</dd><dt><span>units :</span></dt><dd>degrees_east</dd><dt><span>units_long :</span></dt><dd>Degrees East</dd></dl></div><div class='xr-var-data'><pre>array([-180.  , -179.75, -179.5 , ...,  179.25,  179.5 ,  179.75],\n",
+       "      shape=(1440,))</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>lead_day_index</span></div><div class='xr-var-dims'>(lead_day_index)</div><div class='xr-var-dtype'>int64</div><div class='xr-var-preview xr-preview'>0 1 2 3 4 5 6 7 8 9</div><input id='attrs-3f3d6a5f-4fae-4693-8d7d-0954cc7f2a00' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-3f3d6a5f-4fae-4693-8d7d-0954cc7f2a00' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-b664c569-28ea-4589-afb8-c150065bf83e' class='xr-var-data-in' type='checkbox'><label for='data-b664c569-28ea-4589-afb8-c150065bf83e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([0, 1, 2, 3, 4, 5, 6, 7, 8, 9])</pre></div></li><li class='xr-var-item'><div class='xr-var-name'><span class='xr-has-index'>first_day_datetime</span></div><div class='xr-var-dims'>(first_day_datetime)</div><div class='xr-var-dtype'>datetime64[ns]</div><div class='xr-var-preview xr-preview'>2024-01-03 2024-01-10</div><input id='attrs-dbf7b6d0-7e0b-4f08-8d84-fd9c0efbe760' class='xr-var-attrs-in' type='checkbox' disabled><label for='attrs-dbf7b6d0-7e0b-4f08-8d84-fd9c0efbe760' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-13ad50b5-2dce-4c03-b834-ec3b17e80ea0' class='xr-var-data-in' type='checkbox'><label for='data-13ad50b5-2dce-4c03-b834-ec3b17e80ea0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'></dl></div><div class='xr-var-data'><pre>array([&#x27;2024-01-03T00:00:00.000000000&#x27;, &#x27;2024-01-10T00:00:00.000000000&#x27;],\n",
+       "      dtype=&#x27;datetime64[ns]&#x27;)</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-94e7710f-c7c6-4538-bb67-b28d5b3b2b59' class='xr-section-summary-in' type='checkbox'  checked><label for='section-94e7710f-c7c6-4538-bb67-b28d5b3b2b59' class='xr-section-summary' >Data variables: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-var-name'><span>so</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-a25a5dd7-08fb-46ba-b8a7-89df722458ce' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-a25a5dd7-08fb-46ba-b8a7-89df722458ce' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-e17ff96d-ff00-4cd3-83b4-377cc9ef1867' class='xr-var-data-in' type='checkbox'><label for='data-e17ff96d-ff00-4cd3-83b4-377cc9ef1867' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>sea_water_salinity</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -608,7 +608,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>thetao</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-6a319e20-997e-4840-b49d-2c85dcd24446' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-6a319e20-997e-4840-b49d-2c85dcd24446' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-605821a0-a470-4ca9-8186-f9f52d46443d' class='xr-var-data-in' type='checkbox'><label for='data-605821a0-a470-4ca9-8186-f9f52d46443d' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>sea_water_potential_temperature</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>thetao</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-218627b5-f3d5-47a7-b909-e4ccbe0d016d' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-218627b5-f3d5-47a7-b909-e4ccbe0d016d' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-92dc7c7f-9ae0-4b8f-9da4-967b8c6556cb' class='xr-var-data-in' type='checkbox'><label for='data-92dc7c7f-9ae0-4b8f-9da4-967b8c6556cb' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>sea_water_potential_temperature</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -743,7 +743,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>uo</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-2e4fb767-82e2-4cb1-a7b4-f183b97c9c9a' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2e4fb767-82e2-4cb1-a7b4-f183b97c9c9a' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-45ec0c9f-0845-4614-bb1f-efc65fabc1c0' class='xr-var-data-in' type='checkbox'><label for='data-45ec0c9f-0845-4614-bb1f-efc65fabc1c0' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>eastward_sea_water_velocity</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>uo</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-74d91df1-d989-4653-90aa-cd1aeac41e9e' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-74d91df1-d989-4653-90aa-cd1aeac41e9e' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5689b2c5-270c-4e5f-977f-68ffe06ca87c' class='xr-var-data-in' type='checkbox'><label for='data-5689b2c5-270c-4e5f-977f-68ffe06ca87c' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>eastward_sea_water_velocity</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -878,7 +878,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>vo</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-90e8611a-6be2-48c5-bae9-b72204df4f0c' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-90e8611a-6be2-48c5-bae9-b72204df4f0c' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-f6e05a0c-686a-4411-b9b5-322030ea415f' class='xr-var-data-in' type='checkbox'><label for='data-f6e05a0c-686a-4411-b9b5-322030ea415f' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>northward_sea_water_velocity</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>vo</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, depth, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 1, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-52aafd70-0195-4f09-a38e-a428fe0a9e6f' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-52aafd70-0195-4f09-a38e-a428fe0a9e6f' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-a7727a42-08c1-435a-970f-0fbd7a89a99e' class='xr-var-data-in' type='checkbox'><label for='data-a7727a42-08c1-435a-970f-0fbd7a89a99e' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>northward_sea_water_velocity</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1013,7 +1013,7 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>zos</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-98fa3539-5dd7-432a-b964-2304da11170b' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-98fa3539-5dd7-432a-b964-2304da11170b' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-40e1a96a-cd5f-4a9f-9b7c-639177ab76b5' class='xr-var-data-in' type='checkbox'><label for='data-40e1a96a-cd5f-4a9f-9b7c-639177ab76b5' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div><div class='xr-var-data'><table>\n",
+       "</table></div></li><li class='xr-var-item'><div class='xr-var-name'><span>zos</span></div><div class='xr-var-dims'>(first_day_datetime, lead_day_index, lat, lon)</div><div class='xr-var-dtype'>float64</div><div class='xr-var-preview xr-preview'>dask.array&lt;chunksize=(1, 10, 672, 1440), meta=np.ndarray&gt;</div><input id='attrs-2ab40a7d-7468-4c64-a1d0-c798fcea8344' class='xr-var-attrs-in' type='checkbox' ><label for='attrs-2ab40a7d-7468-4c64-a1d0-c798fcea8344' title='Show/Hide attributes'><svg class='icon xr-icon-file-text2'><use xlink:href='#icon-file-text2'></use></svg></label><input id='data-5c780892-a23c-4512-8e0c-6a01adfc3e65' class='xr-var-data-in' type='checkbox'><label for='data-5c780892-a23c-4512-8e0c-6a01adfc3e65' title='Show/Hide data repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-var-attrs'><dl class='xr-attrs'><dt><span>standard_name :</span></dt><dd>sea_surface_height_above_geoid</dd></dl></div><div class='xr-var-data'><table>\n",
        "    <tr>\n",
        "        <td>\n",
        "            <table style=\"border-collapse: collapse;\">\n",
@@ -1108,24 +1108,24 @@
        "</svg>\n",
        "        </td>\n",
        "    </tr>\n",
-       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-9857f33d-dc7e-4cd7-b5c5-7f25a789e406' class='xr-section-summary-in' type='checkbox'  ><label for='section-9857f33d-dc7e-4cd7-b5c5-7f25a789e406' class='xr-section-summary' >Indexes: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>depth</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-17a7fee3-19d5-42c0-947f-cca92615e465' class='xr-index-data-in' type='checkbox'/><label for='index-17a7fee3-19d5-42c0-947f-cca92615e465' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([0.49402499198913574,   47.37369155883789,    92.3260726928711,\n",
+       "</table></div></li></ul></div></li><li class='xr-section-item'><input id='section-8760c95e-acf0-4c43-98e8-fcf5ae6d23df' class='xr-section-summary-in' type='checkbox'  ><label for='section-8760c95e-acf0-4c43-98e8-fcf5ae6d23df' class='xr-section-summary' >Indexes: <span>(5)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><ul class='xr-var-list'><li class='xr-var-item'><div class='xr-index-name'><div>depth</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-ab25927d-d55f-441c-8555-b0c68356e05c' class='xr-index-data-in' type='checkbox'/><label for='index-ab25927d-d55f-441c-8555-b0c68356e05c' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([0.49402499198913574,   47.37369155883789,    92.3260726928711,\n",
        "        155.85069274902344,  222.47520446777344,   318.1274108886719,\n",
        "         380.2130126953125,   453.9377136230469,   541.0889282226562,\n",
        "         643.5667724609375,   763.3331298828125,   902.3392944335938,\n",
        "            1245.291015625,  1684.2840576171875,   2225.077880859375,\n",
        "         3220.820068359375,   3597.031982421875,    3992.48388671875,\n",
        "          4405.22412109375,      4833.291015625,     5274.7841796875],\n",
-       "      dtype=&#x27;float32&#x27;, name=&#x27;depth&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-bca91ca5-314f-4a10-bc9c-f96379f0d95f' class='xr-index-data-in' type='checkbox'/><label for='index-bca91ca5-314f-4a10-bc9c-f96379f0d95f' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -78.0, -77.75,  -77.5, -77.25,  -77.0, -76.75,  -76.5, -76.25,  -76.0,\n",
+       "      dtype=&#x27;float32&#x27;, name=&#x27;depth&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lat</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-d07d7907-6aeb-4954-9742-08b0e230132b' class='xr-index-data-in' type='checkbox'/><label for='index-d07d7907-6aeb-4954-9742-08b0e230132b' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -78.0, -77.75,  -77.5, -77.25,  -77.0, -76.75,  -76.5, -76.25,  -76.0,\n",
        "       -75.75,\n",
        "       ...\n",
        "         87.5,  87.75,   88.0,  88.25,   88.5,  88.75,   89.0,  89.25,   89.5,\n",
        "        89.75],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;lat&#x27;, length=672))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-e17202fe-2e3b-44b6-866b-e4fed06b52b7' class='xr-index-data-in' type='checkbox'/><label for='index-e17202fe-2e3b-44b6-866b-e4fed06b52b7' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -180.0, -179.75,  -179.5, -179.25,  -179.0, -178.75,  -178.5, -178.25,\n",
+       "      dtype=&#x27;float64&#x27;, name=&#x27;lat&#x27;, length=672))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lon</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-9c325a2e-afe9-4916-adf1-c9f96b9affb8' class='xr-index-data-in' type='checkbox'/><label for='index-9c325a2e-afe9-4916-adf1-c9f96b9affb8' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([ -180.0, -179.75,  -179.5, -179.25,  -179.0, -178.75,  -178.5, -178.25,\n",
        "        -178.0, -177.75,\n",
        "       ...\n",
        "         177.5,  177.75,   178.0,  178.25,   178.5,  178.75,   179.0,  179.25,\n",
        "         179.5,  179.75],\n",
-       "      dtype=&#x27;float64&#x27;, name=&#x27;lon&#x27;, length=1440))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lead_day_index</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-e62852ee-821c-44a1-8161-fb4b30c6b2f6' class='xr-index-data-in' type='checkbox'/><label for='index-e62852ee-821c-44a1-8161-fb4b30c6b2f6' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=&#x27;int64&#x27;, name=&#x27;lead_day_index&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>first_day_datetime</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-0ae835bf-4a43-4650-a4a9-dd45eb929c87' class='xr-index-data-in' type='checkbox'/><label for='index-0ae835bf-4a43-4650-a4a9-dd45eb929c87' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2024-01-03&#x27;, &#x27;2024-01-10&#x27;], dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;first_day_datetime&#x27;, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-e4413ba8-a8d5-4d5d-b044-978aff70fc5a' class='xr-section-summary-in' type='checkbox'  checked><label for='section-e4413ba8-a8d5-4d5d-b044-978aff70fc5a' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>regrid_method :</span></dt><dd>bilinear</dd></dl></div></li></ul></div></div>"
+       "      dtype=&#x27;float64&#x27;, name=&#x27;lon&#x27;, length=1440))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>lead_day_index</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-4ec97e38-f50b-41bd-af70-84ba05a1a01d' class='xr-index-data-in' type='checkbox'/><label for='index-4ec97e38-f50b-41bd-af70-84ba05a1a01d' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], dtype=&#x27;int64&#x27;, name=&#x27;lead_day_index&#x27;))</pre></div></li><li class='xr-var-item'><div class='xr-index-name'><div>first_day_datetime</div></div><div class='xr-index-preview'>PandasIndex</div><input type='checkbox' disabled/><label></label><input id='index-c9f433b9-73eb-4924-a7e9-e885f475673e' class='xr-index-data-in' type='checkbox'/><label for='index-c9f433b9-73eb-4924-a7e9-e885f475673e' title='Show/Hide index repr'><svg class='icon xr-icon-database'><use xlink:href='#icon-database'></use></svg></label><div class='xr-index-data'><pre>PandasIndex(DatetimeIndex([&#x27;2024-01-03&#x27;, &#x27;2024-01-10&#x27;], dtype=&#x27;datetime64[ns]&#x27;, name=&#x27;first_day_datetime&#x27;, freq=None))</pre></div></li></ul></div></li><li class='xr-section-item'><input id='section-4e1c804b-0027-4871-8eb9-44837e4dd553' class='xr-section-summary-in' type='checkbox'  checked><label for='section-4e1c804b-0027-4871-8eb9-44837e4dd553' class='xr-section-summary' >Attributes: <span>(1)</span></label><div class='xr-section-inline-details'></div><div class='xr-section-details'><dl class='xr-attrs'><dt><span>regrid_method :</span></dt><dd>bilinear</dd></dl></div></li></ul></div></div>"
       ],
       "text/plain": [
        "<xarray.Dataset> Size: 13GB\n",
@@ -1180,13 +1180,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "db325ae2",
+   "id": "f8917d10",
    "metadata": {
     "papermill": {
-     "duration": 0.003336,
-     "end_time": "2025-06-03T08:26:36.691884",
+     "duration": 0.002864,
+     "end_time": "2025-11-17T11:43:35.933053",
      "exception": false,
-     "start_time": "2025-06-03T08:26:36.688548",
+     "start_time": "2025-11-17T11:43:35.930189",
      "status": "completed"
     },
     "tags": []
@@ -1200,19 +1200,19 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "d0578912",
+   "id": "a3c3360a",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:26:36.700584Z",
-     "iopub.status.busy": "2025-06-03T08:26:36.699636Z",
-     "iopub.status.idle": "2025-06-03T08:26:42.368659Z",
-     "shell.execute_reply": "2025-06-03T08:26:42.368250Z"
+     "iopub.execute_input": "2025-11-17T11:43:35.940805Z",
+     "iopub.status.busy": "2025-11-17T11:43:35.939881Z",
+     "iopub.status.idle": "2025-11-17T11:44:27.832285Z",
+     "shell.execute_reply": "2025-11-17T11:44:27.831847Z"
     },
     "papermill": {
-     "duration": 5.674312,
-     "end_time": "2025-06-03T08:26:42.369425",
+     "duration": 51.901411,
+     "end_time": "2025-11-17T11:44:27.836020",
      "exception": false,
-     "start_time": "2025-06-03T08:26:36.695113",
+     "start_time": "2025-11-17T11:43:35.934609",
      "status": "completed"
     },
     "tags": []
@@ -1547,13 +1547,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "266db52f",
+   "id": "b5b2347d",
    "metadata": {
     "papermill": {
-     "duration": 0.00313,
-     "end_time": "2025-06-03T08:26:42.375674",
+     "duration": 0.002499,
+     "end_time": "2025-11-17T11:44:27.841413",
      "exception": false,
-     "start_time": "2025-06-03T08:26:42.372544",
+     "start_time": "2025-11-17T11:44:27.838914",
      "status": "completed"
     },
     "tags": []
@@ -1565,19 +1565,19 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "1f4d10ab",
+   "id": "c91f67fb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:26:42.382477Z",
-     "iopub.status.busy": "2025-06-03T08:26:42.382067Z",
-     "iopub.status.idle": "2025-06-03T08:27:28.053059Z",
-     "shell.execute_reply": "2025-06-03T08:27:28.052662Z"
+     "iopub.execute_input": "2025-11-17T11:44:27.847920Z",
+     "iopub.status.busy": "2025-11-17T11:44:27.847657Z",
+     "iopub.status.idle": "2025-11-17T11:45:18.940870Z",
+     "shell.execute_reply": "2025-11-17T11:45:18.940534Z"
     },
     "papermill": {
-     "duration": 45.678313,
-     "end_time": "2025-06-03T08:27:28.056965",
+     "duration": 51.101204,
+     "end_time": "2025-11-17T11:45:18.944758",
      "exception": false,
-     "start_time": "2025-06-03T08:26:42.378652",
+     "start_time": "2025-11-17T11:44:27.843554",
      "status": "completed"
     },
     "tags": []
@@ -1622,13 +1622,13 @@
        "      <td>38.100571</td>\n",
        "      <td>39.254677</td>\n",
        "      <td>41.239883</td>\n",
-       "      <td>42.636395</td>\n",
-       "      <td>45.039703</td>\n",
-       "      <td>46.494839</td>\n",
+       "      <td>42.636391</td>\n",
+       "      <td>45.0397</td>\n",
+       "      <td>46.494843</td>\n",
        "      <td>47.829842</td>\n",
-       "      <td>49.770027</td>\n",
+       "      <td>49.770035</td>\n",
        "      <td>50.630898</td>\n",
-       "      <td>52.424088</td>\n",
+       "      <td>52.424095</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
@@ -1636,10 +1636,10 @@
       ],
       "text/plain": [
        "                   Lead day 1  Lead day 2  Lead day 3  Lead day 4  Lead day 5  \\\n",
-       "Mixed layer depth   38.100571   39.254677   41.239883   42.636395   45.039703   \n",
+       "Mixed layer depth   38.100571   39.254677   41.239883   42.636391     45.0397   \n",
        "\n",
        "                   Lead day 6  Lead day 7  Lead day 8  Lead day 9  Lead day 10  \n",
-       "Mixed layer depth   46.494839   47.829842   49.770027   50.630898    52.424088  "
+       "Mixed layer depth   46.494843   47.829842   49.770035   50.630898    52.424095  "
       ]
      },
      "execution_count": 4,
@@ -1653,13 +1653,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a115be32",
+   "id": "0e89ceee",
    "metadata": {
     "papermill": {
-     "duration": 0.003322,
-     "end_time": "2025-06-03T08:27:28.063774",
+     "duration": 0.004925,
+     "end_time": "2025-11-17T11:45:18.969751",
      "exception": false,
-     "start_time": "2025-06-03T08:27:28.060452",
+     "start_time": "2025-11-17T11:45:18.964826",
      "status": "completed"
     },
     "tags": []
@@ -1671,19 +1671,19 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "eb540c0e",
+   "id": "543732cb",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:27:28.072226Z",
-     "iopub.status.busy": "2025-06-03T08:27:28.071755Z",
-     "iopub.status.idle": "2025-06-03T08:27:29.526913Z",
-     "shell.execute_reply": "2025-06-03T08:27:29.526398Z"
+     "iopub.execute_input": "2025-11-17T11:45:18.978605Z",
+     "iopub.status.busy": "2025-11-17T11:45:18.978147Z",
+     "iopub.status.idle": "2025-11-17T11:45:23.494311Z",
+     "shell.execute_reply": "2025-11-17T11:45:23.494019Z"
     },
     "papermill": {
-     "duration": 1.460541,
-     "end_time": "2025-06-03T08:27:29.528055",
+     "duration": 4.522427,
+     "end_time": "2025-11-17T11:45:23.495539",
      "exception": false,
-     "start_time": "2025-06-03T08:27:28.067514",
+     "start_time": "2025-11-17T11:45:18.973112",
      "status": "completed"
     },
     "tags": []
@@ -1782,13 +1782,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8f7e88cc",
+   "id": "9dc98b3c",
    "metadata": {
     "papermill": {
-     "duration": 0.005118,
-     "end_time": "2025-06-03T08:27:29.538912",
+     "duration": 0.002932,
+     "end_time": "2025-11-17T11:45:23.501858",
      "exception": false,
-     "start_time": "2025-06-03T08:27:29.533794",
+     "start_time": "2025-11-17T11:45:23.498926",
      "status": "completed"
     },
     "tags": []
@@ -1800,19 +1800,19 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "3ea921df",
+   "id": "97f20f2c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:27:29.550747Z",
-     "iopub.status.busy": "2025-06-03T08:27:29.550441Z",
-     "iopub.status.idle": "2025-06-03T08:27:47.499589Z",
-     "shell.execute_reply": "2025-06-03T08:27:47.499033Z"
+     "iopub.execute_input": "2025-11-17T11:45:23.508447Z",
+     "iopub.status.busy": "2025-11-17T11:45:23.508234Z",
+     "iopub.status.idle": "2025-11-17T11:45:43.191849Z",
+     "shell.execute_reply": "2025-11-17T11:45:43.191386Z"
     },
     "papermill": {
-     "duration": 17.956433,
-     "end_time": "2025-06-03T08:27:47.500530",
+     "duration": 19.687779,
+     "end_time": "2025-11-17T11:45:43.192333",
      "exception": false,
-     "start_time": "2025-06-03T08:27:29.544097",
+     "start_time": "2025-11-17T11:45:23.504554",
      "status": "completed"
     },
     "tags": []
@@ -1890,13 +1890,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4625537a",
+   "id": "043e7ff4",
    "metadata": {
     "papermill": {
-     "duration": 0.003431,
-     "end_time": "2025-06-03T08:27:47.507520",
+     "duration": 0.003023,
+     "end_time": "2025-11-17T11:45:43.198855",
      "exception": false,
-     "start_time": "2025-06-03T08:27:47.504089",
+     "start_time": "2025-11-17T11:45:43.195832",
      "status": "completed"
     },
     "tags": []
@@ -1908,19 +1908,19 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "2782fc12",
+   "id": "9d97f7f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:27:47.514666Z",
-     "iopub.status.busy": "2025-06-03T08:27:47.514470Z",
-     "iopub.status.idle": "2025-06-03T08:27:52.228342Z",
-     "shell.execute_reply": "2025-06-03T08:27:52.227793Z"
+     "iopub.execute_input": "2025-11-17T11:45:43.204949Z",
+     "iopub.status.busy": "2025-11-17T11:45:43.204799Z",
+     "iopub.status.idle": "2025-11-17T11:46:30.190988Z",
+     "shell.execute_reply": "2025-11-17T11:46:30.190269Z"
     },
     "papermill": {
-     "duration": 4.718604,
-     "end_time": "2025-06-03T08:27:52.229225",
+     "duration": 46.990882,
+     "end_time": "2025-11-17T11:46:30.192846",
      "exception": false,
-     "start_time": "2025-06-03T08:27:47.510621",
+     "start_time": "2025-11-17T11:45:43.201964",
      "status": "completed"
     },
     "tags": []
@@ -2255,13 +2255,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba7fb72e",
+   "id": "a6e52486",
    "metadata": {
     "papermill": {
-     "duration": 0.003782,
-     "end_time": "2025-06-03T08:27:52.237276",
+     "duration": 0.001695,
+     "end_time": "2025-11-17T11:46:30.196370",
      "exception": false,
-     "start_time": "2025-06-03T08:27:52.233494",
+     "start_time": "2025-11-17T11:46:30.194675",
      "status": "completed"
     },
     "tags": []
@@ -2273,19 +2273,19 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "c8ea238c",
+   "id": "28eacf84",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:27:52.246158Z",
-     "iopub.status.busy": "2025-06-03T08:27:52.245893Z",
-     "iopub.status.idle": "2025-06-03T08:28:34.758610Z",
-     "shell.execute_reply": "2025-06-03T08:28:34.758086Z"
+     "iopub.execute_input": "2025-11-17T11:46:30.200450Z",
+     "iopub.status.busy": "2025-11-17T11:46:30.200324Z",
+     "iopub.status.idle": "2025-11-17T11:47:15.418787Z",
+     "shell.execute_reply": "2025-11-17T11:47:15.418062Z"
     },
     "papermill": {
-     "duration": 42.521739,
-     "end_time": "2025-06-03T08:28:34.762814",
+     "duration": 45.222445,
+     "end_time": "2025-11-17T11:47:15.420475",
      "exception": false,
-     "start_time": "2025-06-03T08:27:52.241075",
+     "start_time": "2025-11-17T11:46:30.198030",
      "status": "completed"
     },
     "tags": []
@@ -2332,10 +2332,10 @@
        "      <td>39.227291</td>\n",
        "      <td>40.726135</td>\n",
        "      <td>43.808136</td>\n",
-       "      <td>45.124023</td>\n",
-       "      <td>47.136234</td>\n",
-       "      <td>48.789253</td>\n",
-       "      <td>49.850788</td>\n",
+       "      <td>45.12402</td>\n",
+       "      <td>47.136238</td>\n",
+       "      <td>48.789249</td>\n",
+       "      <td>49.850784</td>\n",
        "      <td>51.309326</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
@@ -2347,7 +2347,7 @@
        "Mixed layer depth   34.805443   36.207138   39.227291   40.726135   43.808136   \n",
        "\n",
        "                   Lead day 6  Lead day 7  Lead day 8  Lead day 9  Lead day 10  \n",
-       "Mixed layer depth   45.124023   47.136234   48.789253   49.850788    51.309326  "
+       "Mixed layer depth    45.12402   47.136238   48.789249   49.850784    51.309326  "
       ]
      },
      "execution_count": 8,
@@ -2361,13 +2361,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a0f6328",
+   "id": "5ffde37e",
    "metadata": {
     "papermill": {
-     "duration": 0.003371,
-     "end_time": "2025-06-03T08:28:34.769895",
+     "duration": 0.001975,
+     "end_time": "2025-11-17T11:47:15.424545",
      "exception": false,
-     "start_time": "2025-06-03T08:28:34.766524",
+     "start_time": "2025-11-17T11:47:15.422570",
      "status": "completed"
     },
     "tags": []
@@ -2379,19 +2379,19 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "56908cee",
+   "id": "d0c6aa69",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:28:34.777539Z",
-     "iopub.status.busy": "2025-06-03T08:28:34.777344Z",
-     "iopub.status.idle": "2025-06-03T08:28:36.034351Z",
-     "shell.execute_reply": "2025-06-03T08:28:36.033871Z"
+     "iopub.execute_input": "2025-11-17T11:47:15.429161Z",
+     "iopub.status.busy": "2025-11-17T11:47:15.429017Z",
+     "iopub.status.idle": "2025-11-17T11:47:28.590993Z",
+     "shell.execute_reply": "2025-11-17T11:47:28.590272Z"
     },
     "papermill": {
-     "duration": 1.262035,
-     "end_time": "2025-06-03T08:28:36.035300",
+     "duration": 13.165053,
+     "end_time": "2025-11-17T11:47:28.591478",
      "exception": false,
-     "start_time": "2025-06-03T08:28:34.773265",
+     "start_time": "2025-11-17T11:47:15.426425",
      "status": "completed"
     },
     "tags": []
@@ -2490,13 +2490,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2cafebb4",
+   "id": "a5c6a383",
    "metadata": {
     "papermill": {
-     "duration": 0.003484,
-     "end_time": "2025-06-03T08:28:36.042737",
+     "duration": 0.019318,
+     "end_time": "2025-11-17T11:47:28.612908",
      "exception": false,
-     "start_time": "2025-06-03T08:28:36.039253",
+     "start_time": "2025-11-17T11:47:28.593590",
      "status": "completed"
     },
     "tags": []
@@ -2508,19 +2508,19 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "id": "85221107",
+   "id": "37269779",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2025-06-03T08:28:36.050543Z",
-     "iopub.status.busy": "2025-06-03T08:28:36.050325Z",
-     "iopub.status.idle": "2025-06-03T08:28:53.459004Z",
-     "shell.execute_reply": "2025-06-03T08:28:53.458413Z"
+     "iopub.execute_input": "2025-11-17T11:47:28.618168Z",
+     "iopub.status.busy": "2025-11-17T11:47:28.618005Z",
+     "iopub.status.idle": "2025-11-17T11:47:56.742544Z",
+     "shell.execute_reply": "2025-11-17T11:47:56.741989Z"
     },
     "papermill": {
-     "duration": 17.41363,
-     "end_time": "2025-06-03T08:28:53.459862",
+     "duration": 28.127746,
+     "end_time": "2025-11-17T11:47:56.742960",
      "exception": false,
-     "start_time": "2025-06-03T08:28:36.046232",
+     "start_time": "2025-11-17T11:47:28.615214",
      "status": "completed"
     },
     "tags": []
@@ -2613,18 +2613,18 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.2"
+   "version": "3.13.9"
   },
   "papermill": {
    "default_parameters": {},
-   "duration": 139.342918,
-   "end_time": "2025-06-03T08:28:53.979206",
+   "duration": 263.805631,
+   "end_time": "2025-11-17T11:47:57.265262",
    "environment_variables": {},
    "exception": null,
    "input_path": "glonet_sample.report.ipynb",
    "output_path": "glonet_sample.report.ipynb",
    "parameters": {},
-   "start_time": "2025-06-03T08:26:34.636288",
+   "start_time": "2025-11-17T11:43:33.459631",
    "version": "2.6.0"
   }
  },

--- a/oceanbench/core/mixed_layer_depth.py
+++ b/oceanbench/core/mixed_layer_depth.py
@@ -38,6 +38,8 @@ def _compute_potential_density(
     temperature: xarray.DataArray,
     depth: xarray.DataArray,
 ) -> xarray.DataArray:
+    absolute_salinity = absolute_salinity.clip(min=0)  # filter out negative salinities
+
     return gsw.pot_rho_t_exact(absolute_salinity, temperature, depth, 0)
 
 


### PR DESCRIPTION
In the computing of the mixed layer depth score, the function gsw.pot_rho_exact_t wasn't running properly because of certain values outside its validity domain (salinity negative values), this is a quick patch to clip those values to 0, now the function stops outputting an error but the make run-tests will output a small difference in scores, in the order of 10⁻5 meters.
