### PR TITLE
opti: makefile parallelization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,17 +48,35 @@ evaluate-challenger: SELECTED_ENVIRONMENT_NAME = ${TEST_ENVIRONMENT_NAME}
 evaluate-challenger:
 	${ACTIVATE_ENVIRONMENT}
 	pip install --editable .
+	$(MAKE) _evaluate-challenger
+
+_evaluate-challenger: SELECTED_ENVIRONMENT_NAME = ${TEST_ENVIRONMENT_NAME}
+_evaluate-challenger:
+	${ACTIVATE_ENVIRONMENT}
 	python -c 'import oceanbench; oceanbench.evaluate_challenger("$(CHALLENGER_PYTHON_FILE_PATH)", "$(CHALLENGER_REPORT_NAME)", "$(OUTPUT_BUCKET)", "$(OUTPUT_PREFIX)")'
+
+evaluate-glonet-sample:
+	$(MAKE) _evaluate-challenger CHALLENGER_PYTHON_FILE_PATH=assets/glonet_sample.py CHALLENGER_REPORT_NAME=glonet_sample.report.ipynb
+
+evaluate-xihe-sample:
+	$(MAKE) _evaluate-challenger CHALLENGER_PYTHON_FILE_PATH=assets/xihe_sample.py CHALLENGER_REPORT_NAME=xihe_sample.report.ipynb
+
+evaluate-wenhai-sample:
+	$(MAKE) _evaluate-challenger CHALLENGER_PYTHON_FILE_PATH=assets/wenhai_sample.py CHALLENGER_REPORT_NAME=wenhai_sample.report.ipynb
+
+compare-notebooks: SELECTED_ENVIRONMENT_NAME = ${TEST_ENVIRONMENT_NAME}
+compare-notebooks:
+	${ACTIVATE_ENVIRONMENT}
+	python tests/compare_notebook.py assets/glonet_sample.report.ipynb glonet_sample.report.ipynb
+	python tests/compare_notebook.py assets/xihe_sample.report.ipynb xihe_sample.report.ipynb
+	python tests/compare_notebook.py assets/wenhai_sample.report.ipynb wenhai_sample.report.ipynb
 
 run-tests: SELECTED_ENVIRONMENT_NAME = ${TEST_ENVIRONMENT_NAME}
 run-tests:
 	${ACTIVATE_ENVIRONMENT}
-	$(MAKE) evaluate-challenger CHALLENGER_PYTHON_FILE_PATH=assets/glonet_sample.py CHALLENGER_REPORT_NAME=glonet_sample.report.ipynb
-	python tests/compare_notebook.py assets/glonet_sample.report.ipynb glonet_sample.report.ipynb
-	$(MAKE) evaluate-challenger CHALLENGER_PYTHON_FILE_PATH=assets/xihe_sample.py CHALLENGER_REPORT_NAME=xihe_sample.report.ipynb
-	python tests/compare_notebook.py assets/xihe_sample.report.ipynb xihe_sample.report.ipynb
-	$(MAKE) evaluate-challenger CHALLENGER_PYTHON_FILE_PATH=assets/wenhai_sample.py CHALLENGER_REPORT_NAME=wenhai_sample.report.ipynb
-	python tests/compare_notebook.py assets/wenhai_sample.report.ipynb wenhai_sample.report.ipynb
+	pip install --editable .
+	$(MAKE) -j3 evaluate-glonet-sample evaluate-xihe-sample evaluate-wenhai-sample
+	$(MAKE) compare-notebooks
 	poetry run pytest --doctest-modules oceanbench/datasets/* -n 8
 
 _release: SELECTED_ENVIRONMENT_NAME = ${ENVIRONMENT_NAME}


### PR DESCRIPTION
the first quick win i found was to parallelize make-tests (launched with -j3)
CI down to 25min, @ZakariaAissaabdi reproduced it locally too
i'll create a new branch if i find other optimizations later (i'm thinking about MLD computing/caching maybe)