### PR TITLE
OceanBench Release 0.1.1

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,18 +3,7 @@
 # SPDX-License-Identifier: EUPL-1.2
 
 name: Publish OceanBench to PyPI
-on:
-  push:
-  workflow_dispatch:
-    inputs:
-      git_ref:
-        description: "Git ref to publish, for example v1.0.0"
-        required: true
-        type: string
-      expected_version:
-        description: "Expected package version, for example 1.0.0"
-        required: true
-        type: string
+on: push
 jobs:
   build:
     name: Build distribution
@@ -22,7 +11,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || github.ref }}
           persist-credentials: false
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -30,11 +18,6 @@ jobs:
           python-version: "3.x"
       - name: Install pypa/build
         run: python3 -m pip install build --user
-      - name: Check package version
-        if: ${{ github.event_name == 'workflow_dispatch' }}
-        run: |
-          VERSION=$(python3 -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
-          test "$VERSION" = "${{ inputs.expected_version }}"
       - name: Build a binary wheel and a source tarball
         run: python3 -m build
       - name: Store the distribution packages
@@ -44,7 +27,7 @@ jobs:
           path: dist/
   publish-to-pypi:
     name: Publish to PyPI
-    if: ${{ github.event_name == 'workflow_dispatch' || (startsWith(github.event.head_commit.message, 'OceanBench Release') && github.ref == 'refs/heads/main') }}
+    if: ${{ startsWith(github.event.head_commit.message, 'OceanBench Release') && github.ref == 'refs/heads/main' }}
     needs:
       - build
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,43 @@
+<!--
+SPDX-FileCopyrightText: 2025 Mercator Ocean International <https://www.mercator-ocean.eu/>
+
+SPDX-License-Identifier: EUPL-1.2
+-->
+
+# Changelog
+
+All notable changes to OceanBench are documented in this file.
+
+## 0.1.1 - 2026-05-06
+
+### Added
+
+- Regional evaluation support.
+- IBI benchmark region support.
+- Region-aware report generation and website display.
+- Official global and IBI benchmark report storage under `public/evaluation-reports/0.1.1/`.
+
+### Changed
+
+- Evaluation report filenames now include the evaluated region: `{challenger}.{region}.report.ipynb`.
+
+### Reports
+
+- Official reports: `public/evaluation-reports/0.1.1/`
+
+## 0.1.0 - 2026-05-06
+
+### Added
+
+- Interactive OceanBench website based on generated evaluation notebooks.
+- Class IV observation validation support.
+- Local staging and remote retry support for large evaluations.
+- Official global benchmark report storage under `public/evaluation-reports/0.1.0/`.
+
+### Changed
+
+- Evaluation reports are generated as notebooks and parsed by the website to populate benchmark score tables.
+
+### Reports
+
+- Official reports: `public/evaluation-reports/0.1.0/`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 
 [project]
 name = "oceanbench"
-version = "0.0.3"
+version = "0.1.1"
 description = ""
 authors = [
     {name = "Mercator Ocean International",email = "digital-ocean-dev@mercator-ocean.eu"},


### PR DESCRIPTION
Release 0.1.1 prepares the regional/IBI benchmark release.

Changes:
- Bump package version to 0.1.1.
- Point the website to public/evaluation-reports/0.1.1/.
- Add CHANGELOG entries for 0.1.0 and 0.1.1.
- Remove the temporary manual PyPI publish mode now that 0.1.0 has been published.

Do not merge until the 0.1.0 official notebooks are generated and uploaded.