### PR TITLE
Resolve website reports from manifest

### DIFF
--- a/tests/test_website_s3_discovery.py
+++ b/tests/test_website_s3_discovery.py
@@ -17,10 +17,14 @@ from helpers.published_regions import published_region_metadata  # noqa: E402
 
 
 class MockResponse:
-    def __init__(self, status_code: int, text: str = "", content: bytes = b""):
+    def __init__(self, status_code: int, text: str = "", content: bytes = b"", json_data: dict | None = None):
         self.status_code = status_code
         self.text = text
         self.content = content
+        self._json_data = {} if json_data is None else json_data
+
+    def json(self) -> dict:
+        return self._json_data
 
 
 def test_discover_official_reports_probes_only_official_region_report_names(monkeypatch) -> None:
@@ -31,11 +35,17 @@ def test_discover_official_reports_probes_only_official_region_report_names(monk
     }
     requested_urls = []
 
+    def fake_get(url: str, timeout: int):
+        assert url == "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/current.json"
+        assert timeout == 10
+        return MockResponse(status_code=404)
+
     def fake_head(url: str, timeout: int):
         assert timeout == 10
         requested_urls.append(url)
         return MockResponse(status_code=200 if url in existing_report_urls else 404)
 
+    monkeypatch.setattr("helpers.s3_discovery.requests.get", fake_get)
     monkeypatch.setattr("helpers.s3_discovery.requests.head", fake_head)
 
     reports = discover_official_reports()
@@ -48,6 +58,69 @@ def test_discover_official_reports_probes_only_official_region_report_names(monk
         ".report.ipynb" in url and ".global.report.ipynb" not in url and ".ibi.report.ipynb" not in url
         for url in requested_urls
     )
+
+
+def test_discover_official_reports_uses_manifest_current_version(monkeypatch) -> None:
+    existing_report_urls = {
+        "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/0.1.1/glo12.global.report.ipynb",
+    }
+
+    def fake_get(url: str, timeout: int):
+        assert url == "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/current.json"
+        assert timeout == 10
+        return MockResponse(status_code=200, json_data={"current": "0.1.1"})
+
+    def fake_head(url: str, timeout: int):
+        assert timeout == 10
+        return MockResponse(status_code=200 if url in existing_report_urls else 404)
+
+    monkeypatch.setattr("helpers.s3_discovery.requests.get", fake_get)
+    monkeypatch.setattr("helpers.s3_discovery.requests.head", fake_head)
+
+    reports = discover_official_reports()
+
+    assert reports["global"] == ["glo12"]
+    assert reports["ibi"] == []
+
+
+def test_discover_official_reports_falls_back_when_manifest_is_missing(monkeypatch) -> None:
+    existing_report_urls = {
+        "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/1.1.0/glo12.global.report.ipynb",
+    }
+
+    def fake_get(url: str, timeout: int):
+        return MockResponse(status_code=404)
+
+    def fake_head(url: str, timeout: int):
+        return MockResponse(status_code=200 if url in existing_report_urls else 404)
+
+    monkeypatch.setattr("helpers.s3_discovery.requests.get", fake_get)
+    monkeypatch.setattr("helpers.s3_discovery.requests.head", fake_head)
+
+    reports = discover_official_reports()
+
+    assert reports["global"] == ["glo12"]
+    assert reports["ibi"] == []
+
+
+def test_discover_official_reports_falls_back_when_manifest_is_invalid(monkeypatch) -> None:
+    existing_report_urls = {
+        "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/1.1.0/glo12.global.report.ipynb",
+    }
+
+    def fake_get(url: str, timeout: int):
+        return MockResponse(status_code=200, json_data={"current": "../0.1.1"})
+
+    def fake_head(url: str, timeout: int):
+        return MockResponse(status_code=200 if url in existing_report_urls else 404)
+
+    monkeypatch.setattr("helpers.s3_discovery.requests.get", fake_get)
+    monkeypatch.setattr("helpers.s3_discovery.requests.head", fake_head)
+
+    reports = discover_official_reports()
+
+    assert reports["global"] == ["glo12"]
+    assert reports["ibi"] == []
 
 
 def test_published_regions_have_stable_order_and_metadata() -> None:
@@ -104,7 +177,11 @@ def test_download_notebook_uses_only_explicit_region_name(monkeypatch, tmp_path)
     assert (tmp_path / "glonet.global.report.ipynb").read_bytes() == b"{}"
     assert requests_seen == [
         (
+            "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/current.json",
+            10,
+        ),
+        (
             "https://minio.dive.edito.eu/project-oceanbench/public/evaluation-reports/1.1.0/glonet.global.report.ipynb",
             30,
-        )
+        ),
     ]

--- a/website/helpers/s3_discovery.py
+++ b/website/helpers/s3_discovery.py
@@ -11,12 +11,33 @@ from helpers.challenger_metadata import KNOWN_CHALLENGERS
 from helpers.published_regions import published_region_ids
 
 S3_BASE_URL = "https://minio.dive.edito.eu/project-oceanbench"
-REPORTS_PREFIX = "public/evaluation-reports/1.1.0/"
+REPORTS_MANIFEST_PATH = "public/evaluation-reports/current.json"
+DEFAULT_REPORTS_VERSION = "1.1.0"
 REPORT_FILE_PATTERN = re.compile(r"^(?P<challenger>.+)\.(?P<region>[a-z0-9_-]+)\.report\.ipynb$")
 
 
+def _report_prefix() -> str:
+    return f"public/evaluation-reports/{_current_report_version()}/"
+
+
+def _current_report_version() -> str:
+    try:
+        response = requests.get(f"{S3_BASE_URL}/{REPORTS_MANIFEST_PATH}", timeout=10)
+        if response.status_code != 200:
+            return DEFAULT_REPORTS_VERSION
+        manifest = response.json()
+        current_version = manifest.get("current")
+        return current_version if _valid_report_version(current_version) else DEFAULT_REPORTS_VERSION
+    except Exception:
+        return DEFAULT_REPORTS_VERSION
+
+
+def _valid_report_version(version: object) -> bool:
+    return isinstance(version, str) and re.fullmatch(r"\d+\.\d+\.\d+", version) is not None
+
+
 def _notebook_url(challenger_name: str, region_id: str) -> str:
-    return f"{S3_BASE_URL}/{REPORTS_PREFIX}{challenger_name}.{region_id}.report.ipynb"
+    return f"{S3_BASE_URL}/{_report_prefix()}{challenger_name}.{region_id}.report.ipynb"
 
 
 def _report_exists(challenger_name: str, region_id: str) -> bool:


### PR DESCRIPTION
Adds a report-version manifest lookup for the website report downloader.

Behavior:
- Reads public/evaluation-reports/current.json during website pre-render.
- Downloads reports from public/evaluation-reports/<current>/.
- Falls back to the existing 1.1.0 prefix if the manifest is missing, unavailable, or invalid.

This decouples package releases from slow report generation. Future report promotion only needs updating current.json after a report prefix has been generated and validated.

Initial recommended manifest content while keeping current behavior:

```json
{
  "current": "1.1.0",
  "available": ["1.1.0"]
}
```

After 0.1.1 reports are ready, update the bucket manifest to current=0.1.1.