### PR TITLE
fix depth-dependent reference staging cache

### DIFF
--- a/oceanbench/core/dataset_source.py
+++ b/oceanbench/core/dataset_source.py
@@ -9,6 +9,7 @@ import xarray
 DATASET_SOURCE_KIND_ATTRIBUTE = "oceanbench_source_kind"
 DATASET_SOURCE_NAME_ATTRIBUTE = "oceanbench_source_name"
 DATASET_SOURCE_RESOLUTION_ATTRIBUTE = "oceanbench_source_resolution"
+DATASET_SOURCE_VARIANT_ATTRIBUTE = "oceanbench_source_variant"
 
 
 @dataclass(frozen=True)
@@ -16,6 +17,7 @@ class DatasetSource:
     kind: str
     name: str
     resolution: str | None = None
+    variant: str | None = None
 
 
 def with_dataset_source(
@@ -24,6 +26,7 @@ def with_dataset_source(
     kind: str,
     name: str,
     resolution: str | None = None,
+    variant: str | None = None,
 ) -> xarray.Dataset:
     attrs = dict(dataset.attrs)
     attrs[DATASET_SOURCE_KIND_ATTRIBUTE] = kind
@@ -32,6 +35,10 @@ def with_dataset_source(
         attrs.pop(DATASET_SOURCE_RESOLUTION_ATTRIBUTE, None)
     else:
         attrs[DATASET_SOURCE_RESOLUTION_ATTRIBUTE] = resolution
+    if variant is None:
+        attrs.pop(DATASET_SOURCE_VARIANT_ATTRIBUTE, None)
+    else:
+        attrs[DATASET_SOURCE_VARIANT_ATTRIBUTE] = variant
     return dataset.assign_attrs(attrs)
 
 
@@ -41,4 +48,5 @@ def get_dataset_source(dataset: xarray.Dataset) -> DatasetSource | None:
     if kind in (None, "") or name in (None, ""):
         return None
     resolution = dataset.attrs.get(DATASET_SOURCE_RESOLUTION_ATTRIBUTE)
-    return DatasetSource(kind=kind, name=name, resolution=resolution)
+    variant = dataset.attrs.get(DATASET_SOURCE_VARIANT_ATTRIBUTE)
+    return DatasetSource(kind=kind, name=name, resolution=resolution, variant=variant)

--- a/oceanbench/core/lagrangian_support.py
+++ b/oceanbench/core/lagrangian_support.py
@@ -58,8 +58,9 @@ def _lagrangian_stage_sources(
 
 def _lagrangian_stage_directory(dataset_source: DatasetSource, lead_days_count: int) -> Path:
     resolution_suffix = "" if dataset_source.resolution is None else f"-{dataset_source.resolution}"
+    variant_suffix = "" if dataset_source.variant is None else f"-{dataset_source.variant}"
     return local_stage_directory() / (
-        f"lagrangian-{dataset_source.kind}-{dataset_source.name}{resolution_suffix}-{lead_days_count}d"
+        f"lagrangian-{dataset_source.kind}-{dataset_source.name}{resolution_suffix}{variant_suffix}-{lead_days_count}d"
     )
 
 

--- a/oceanbench/core/reference_depths.py
+++ b/oceanbench/core/reference_depths.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2025 Mercator Ocean International <https://www.mercator-ocean.eu/>
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+import hashlib
+
+import numpy
+import xarray
+
+REFERENCE_DEPTH_GRID_ROUNDING_DECIMALS = 3
+REFERENCE_DEPTH_GRID_HASH_ATTRIBUTE = "oceanbench_reference_depth_grid_hash"
+REFERENCE_DEPTH_GRID_ROUNDING_ATTRIBUTE = "oceanbench_reference_depth_grid_rounding_decimals"
+REFERENCE_TARGET_DEPTHS_ATTRIBUTE = "oceanbench_reference_target_depths_m"
+
+
+def normalised_reference_depths(target_depths: numpy.ndarray) -> numpy.ndarray:
+    depths = numpy.asarray(target_depths, dtype=numpy.float64)
+    if depths.ndim != 1:
+        raise ValueError("Reference target depths must be a one-dimensional array.")
+    if depths.size == 0:
+        raise ValueError("Reference target depths cannot be empty.")
+    if not numpy.all(numpy.isfinite(depths)):
+        raise ValueError("Reference target depths must be finite.")
+    return numpy.round(depths, REFERENCE_DEPTH_GRID_ROUNDING_DECIMALS)
+
+
+def reference_depth_grid_hash(target_depths: numpy.ndarray) -> str:
+    rounded_depths = normalised_reference_depths(target_depths)
+    payload = ",".join(f"{depth:.{REFERENCE_DEPTH_GRID_ROUNDING_DECIMALS}f}" for depth in rounded_depths)
+    return hashlib.sha256(payload.encode("ascii")).hexdigest()[:12]
+
+
+def reference_depth_grid_stage_variant(target_depths: numpy.ndarray) -> str:
+    rounded_depths = normalised_reference_depths(target_depths)
+    return f"depths-{len(rounded_depths)}-{reference_depth_grid_hash(rounded_depths)}"
+
+
+def with_reference_depth_grid_metadata(dataset: xarray.Dataset, target_depths: numpy.ndarray) -> xarray.Dataset:
+    rounded_depths = normalised_reference_depths(target_depths)
+    attrs = dict(dataset.attrs)
+    attrs[REFERENCE_DEPTH_GRID_HASH_ATTRIBUTE] = reference_depth_grid_hash(rounded_depths)
+    attrs[REFERENCE_DEPTH_GRID_ROUNDING_ATTRIBUTE] = REFERENCE_DEPTH_GRID_ROUNDING_DECIMALS
+    attrs[REFERENCE_TARGET_DEPTHS_ATTRIBUTE] = rounded_depths.tolist()
+    return dataset.assign_attrs(attrs)

--- a/oceanbench/core/references/glo12.py
+++ b/oceanbench/core/references/glo12.py
@@ -11,6 +11,10 @@ from oceanbench.core.dataset_utils import Dimension
 from oceanbench.core.resolution import get_dataset_resolution
 import copernicusmarine
 from oceanbench.core.climate_forecast_standard_names import StandardVariable
+from oceanbench.core.reference_depths import (
+    reference_depth_grid_stage_variant,
+    with_reference_depth_grid_metadata,
+)
 from oceanbench.core.remote_http import with_remote_http_retries
 from oceanbench.core.weekly_stage import maybe_stage_weekly_dataset, prepare_reference_week_dataset
 
@@ -109,21 +113,32 @@ def _glo12_1_12_path(first_day_datetime, days_count: int, target_depths: numpy.n
     return dataset
 
 
+def _prepare_glo12_1_12_week_dataset(
+    first_day_datetime: numpy.datetime64,
+    lead_days_count: int,
+    target_depths: numpy.ndarray,
+) -> Dataset:
+    return with_reference_depth_grid_metadata(
+        prepare_reference_week_dataset(
+            _glo12_1_12_path(first_day_datetime, days_count=lead_days_count, target_depths=target_depths),
+            lead_days_count=lead_days_count,
+            operation_name="GLO12 twelfth-degree dataset open",
+        ),
+        target_depths,
+    )
+
+
 def _glo12_analysis_dataset_1_12(challenger_dataset: Dataset) -> Dataset:
     first_day_datetimes = challenger_dataset[Dimension.FIRST_DAY_DATETIME.key()].values
     lead_days_count = challenger_dataset.sizes[Dimension.LEAD_DAY_INDEX.key()]
 
     target_depths = challenger_dataset[Dimension.DEPTH.key()].values
+    stage_variant = reference_depth_grid_stage_variant(target_depths)
 
     def open_remote_dataset() -> Dataset:
         datasets = []
         for first_day_datetime in first_day_datetimes:
-            dataset = _glo12_1_12_path(first_day_datetime, days_count=lead_days_count, target_depths=target_depths)
-            dataset = prepare_reference_week_dataset(
-                dataset,
-                lead_days_count=lead_days_count,
-                operation_name="GLO12 twelfth-degree dataset open",
-            )
+            dataset = _prepare_glo12_1_12_week_dataset(first_day_datetime, lead_days_count, target_depths)
             datasets.append(dataset)
 
         return concat(datasets, dim=Dimension.FIRST_DAY_DATETIME.key()).assign_coords(
@@ -136,13 +151,12 @@ def _glo12_analysis_dataset_1_12(challenger_dataset: Dataset) -> Dataset:
         dataset_name="glo12",
         first_day_datetimes=first_day_datetimes,
         lead_days_count=lead_days_count,
-        open_week_dataset=lambda first_day_datetime: prepare_reference_week_dataset(
-            _glo12_1_12_path(first_day_datetime, days_count=lead_days_count, target_depths=target_depths),
-            lead_days_count=lead_days_count,
-            operation_name="GLO12 twelfth-degree dataset open",
+        open_week_dataset=lambda first_day_datetime: _prepare_glo12_1_12_week_dataset(
+            first_day_datetime, lead_days_count, target_depths
         ),
         open_remote_dataset=open_remote_dataset,
         resolution="twelfth_degree",
+        stage_variant=stage_variant,
     )
 
 

--- a/oceanbench/core/references/glorys.py
+++ b/oceanbench/core/references/glorys.py
@@ -11,6 +11,10 @@ import copernicusmarine
 from oceanbench.core.resolution import get_dataset_resolution
 from oceanbench.core.dataset_utils import Dimension
 from oceanbench.core.climate_forecast_standard_names import StandardVariable
+from oceanbench.core.reference_depths import (
+    reference_depth_grid_stage_variant,
+    with_reference_depth_grid_metadata,
+)
 from oceanbench.core.remote_http import with_remote_http_retries
 from oceanbench.core.weekly_stage import maybe_stage_weekly_dataset, prepare_reference_week_dataset
 
@@ -80,21 +84,32 @@ def _glorys_1_12_path(first_day_datetime, days_count: int, target_depths: numpy.
     return dataset
 
 
+def _prepare_glorys_1_12_week_dataset(
+    first_day_datetime: numpy.datetime64,
+    lead_days_count: int,
+    target_depths: numpy.ndarray,
+) -> Dataset:
+    return with_reference_depth_grid_metadata(
+        prepare_reference_week_dataset(
+            _glorys_1_12_path(first_day_datetime, days_count=lead_days_count, target_depths=target_depths),
+            lead_days_count=lead_days_count,
+            operation_name="GLORYS twelfth-degree dataset open",
+        ),
+        target_depths,
+    )
+
+
 def _glorys_reanalysis_dataset_1_12(challenger_dataset: Dataset) -> Dataset:
     first_day_datetimes = challenger_dataset[Dimension.FIRST_DAY_DATETIME.key()].values
     lead_days_count = challenger_dataset.sizes[Dimension.LEAD_DAY_INDEX.key()]
 
     target_depths = challenger_dataset[Dimension.DEPTH.key()].values
+    stage_variant = reference_depth_grid_stage_variant(target_depths)
 
     def open_remote_dataset() -> Dataset:
         datasets = []
         for first_day_datetime in first_day_datetimes:
-            dataset = _glorys_1_12_path(first_day_datetime, days_count=lead_days_count, target_depths=target_depths)
-            dataset = prepare_reference_week_dataset(
-                dataset,
-                lead_days_count=lead_days_count,
-                operation_name="GLORYS twelfth-degree dataset open",
-            )
+            dataset = _prepare_glorys_1_12_week_dataset(first_day_datetime, lead_days_count, target_depths)
             datasets.append(dataset)
 
         return concat(datasets, dim=Dimension.FIRST_DAY_DATETIME.key()).assign_coords(
@@ -107,13 +122,12 @@ def _glorys_reanalysis_dataset_1_12(challenger_dataset: Dataset) -> Dataset:
         dataset_name="glorys",
         first_day_datetimes=first_day_datetimes,
         lead_days_count=lead_days_count,
-        open_week_dataset=lambda first_day_datetime: prepare_reference_week_dataset(
-            _glorys_1_12_path(first_day_datetime, days_count=lead_days_count, target_depths=target_depths),
-            lead_days_count=lead_days_count,
-            operation_name="GLORYS twelfth-degree dataset open",
+        open_week_dataset=lambda first_day_datetime: _prepare_glorys_1_12_week_dataset(
+            first_day_datetime, lead_days_count, target_depths
         ),
         open_remote_dataset=open_remote_dataset,
         resolution="twelfth_degree",
+        stage_variant=stage_variant,
     )
 
 

--- a/oceanbench/core/weekly_stage.py
+++ b/oceanbench/core/weekly_stage.py
@@ -26,9 +26,14 @@ def _weekly_stage_directory(
     dataset_name: str,
     lead_days_count: int,
     resolution: str | None = None,
+    stage_variant: str | None = None,
 ) -> Path:
     resolution_suffix = "" if resolution is None else f"-{resolution}"
-    return local_stage_directory() / f"{dataset_kind}-{dataset_name}{resolution_suffix}-{lead_days_count}d"
+    stage_variant_suffix = "" if stage_variant is None else f"-{stage_variant}"
+    return (
+        local_stage_directory()
+        / f"{dataset_kind}-{dataset_name}{resolution_suffix}{stage_variant_suffix}-{lead_days_count}d"
+    )
 
 
 def _weekly_stage_path(
@@ -37,9 +42,13 @@ def _weekly_stage_path(
     lead_days_count: int,
     first_day_datetime: numpy.datetime64 | datetime,
     resolution: str | None = None,
+    stage_variant: str | None = None,
 ) -> Path:
     first_day = datetime.fromisoformat(str(first_day_datetime)).strftime("%Y%m%d")
-    return _weekly_stage_directory(dataset_kind, dataset_name, lead_days_count, resolution) / f"{first_day}.zarr"
+    return (
+        _weekly_stage_directory(dataset_kind, dataset_name, lead_days_count, resolution, stage_variant)
+        / f"{first_day}.zarr"
+    )
 
 
 def staged_weekly_dataset(
@@ -50,6 +59,7 @@ def staged_weekly_dataset(
     lead_days_count: int,
     open_week_dataset: Callable[[numpy.datetime64], xarray.Dataset],
     resolution: str | None = None,
+    stage_variant: str | None = None,
 ) -> xarray.Dataset:
     def stage_week(first_day_datetime: numpy.datetime64) -> Path:
         stage_path = _weekly_stage_path(
@@ -58,6 +68,7 @@ def staged_weekly_dataset(
             lead_days_count=lead_days_count,
             first_day_datetime=first_day_datetime,
             resolution=resolution,
+            stage_variant=stage_variant,
         )
 
         def build_stage(path: Path) -> None:
@@ -85,6 +96,7 @@ def staged_weekly_dataset(
         kind=dataset_kind,
         name=dataset_name,
         resolution=resolution,
+        variant=stage_variant,
     )
 
 
@@ -98,6 +110,7 @@ def maybe_stage_weekly_dataset(
     open_week_dataset: Callable[[numpy.datetime64], xarray.Dataset],
     open_remote_dataset: Callable[[], xarray.Dataset],
     resolution: str | None = None,
+    stage_variant: str | None = None,
     attach_source_metadata_when_not_staged: bool = True,
 ) -> xarray.Dataset:
     if should_stage_locally(stage_key):
@@ -108,6 +121,7 @@ def maybe_stage_weekly_dataset(
             lead_days_count=lead_days_count,
             open_week_dataset=open_week_dataset,
             resolution=resolution,
+            stage_variant=stage_variant,
         )
     remote_dataset = open_remote_dataset()
     if not attach_source_metadata_when_not_staged:
@@ -117,6 +131,7 @@ def maybe_stage_weekly_dataset(
         kind=dataset_kind,
         name=dataset_name,
         resolution=resolution,
+        variant=stage_variant,
     )
 
 

--- a/tests/test_reference_depths.py
+++ b/tests/test_reference_depths.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2025 Mercator Ocean International <https://www.mercator-ocean.eu/>
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+from pathlib import Path
+
+import numpy
+import xarray
+
+from oceanbench.core.dataset_utils import Dimension
+from oceanbench.core.dataset_source import DatasetSource, get_dataset_source, with_dataset_source
+from oceanbench.core.lagrangian_support import _lagrangian_stage_directory
+from oceanbench.core.reference_depths import (
+    REFERENCE_DEPTH_GRID_HASH_ATTRIBUTE,
+    REFERENCE_DEPTH_GRID_ROUNDING_ATTRIBUTE,
+    REFERENCE_DEPTH_GRID_ROUNDING_DECIMALS,
+    REFERENCE_TARGET_DEPTHS_ATTRIBUTE,
+    reference_depth_grid_stage_variant,
+    with_reference_depth_grid_metadata,
+)
+from oceanbench.core.references import glo12, glorys
+from oceanbench.core.weekly_stage import _weekly_stage_directory, maybe_stage_weekly_dataset
+
+
+def _challenger_dataset(depths: list[float]) -> xarray.Dataset:
+    return xarray.Dataset(
+        coords={
+            Dimension.FIRST_DAY_DATETIME.key(): [numpy.datetime64("2024-01-03")],
+            Dimension.LEAD_DAY_INDEX.key(): [0, 1],
+            Dimension.DEPTH.key(): depths,
+        }
+    )
+
+
+def test_reference_depth_grid_stage_variant_uses_rounded_depths() -> None:
+    xihe_depths = numpy.array([0.494, 2.6457, 5.0782, 7.9296])
+    wenhai_depths = numpy.array([0.494025, 2.645669, 5.078224, 7.929560])
+    glo12_depths = numpy.array([0.494025, 47.37369, 92.32607, 155.8507])
+
+    assert reference_depth_grid_stage_variant(xihe_depths) == reference_depth_grid_stage_variant(wenhai_depths)
+    assert reference_depth_grid_stage_variant(xihe_depths) != reference_depth_grid_stage_variant(glo12_depths)
+
+
+def test_with_reference_depth_grid_metadata_records_auditable_depth_grid() -> None:
+    target_depths = numpy.array([0.494025, 2.645669])
+    dataset = xarray.Dataset()
+
+    dataset_with_metadata = with_reference_depth_grid_metadata(dataset, target_depths)
+
+    assert dataset_with_metadata.attrs[REFERENCE_DEPTH_GRID_HASH_ATTRIBUTE]
+    assert (
+        dataset_with_metadata.attrs[REFERENCE_DEPTH_GRID_ROUNDING_ATTRIBUTE] == REFERENCE_DEPTH_GRID_ROUNDING_DECIMALS
+    )
+    assert dataset_with_metadata.attrs[REFERENCE_TARGET_DEPTHS_ATTRIBUTE] == [0.494, 2.646]
+
+
+def test_glorys_twelfth_degree_reference_stage_variant_depends_on_target_depth_grid(monkeypatch) -> None:
+    captured_variants = []
+
+    def fake_maybe_stage_weekly_dataset(**kwargs):
+        captured_variants.append((kwargs["resolution"], kwargs["stage_variant"]))
+        return xarray.Dataset()
+
+    monkeypatch.setattr(glorys, "maybe_stage_weekly_dataset", fake_maybe_stage_weekly_dataset)
+
+    glorys._glorys_reanalysis_dataset_1_12(_challenger_dataset([0.494, 2.6457]))
+    glorys._glorys_reanalysis_dataset_1_12(_challenger_dataset([0.494025, 2.645669]))
+    glorys._glorys_reanalysis_dataset_1_12(_challenger_dataset([0.494025, 47.37369]))
+
+    assert captured_variants[0][0] == "twelfth_degree"
+    assert captured_variants[0][1] == captured_variants[1][1]
+    assert captured_variants[0][1] != captured_variants[2][1]
+
+
+def test_glo12_twelfth_degree_reference_stage_variant_depends_on_target_depth_grid(monkeypatch) -> None:
+    captured_variants = []
+
+    def fake_maybe_stage_weekly_dataset(**kwargs):
+        captured_variants.append((kwargs["resolution"], kwargs["stage_variant"]))
+        return xarray.Dataset()
+
+    monkeypatch.setattr(glo12, "maybe_stage_weekly_dataset", fake_maybe_stage_weekly_dataset)
+
+    glo12._glo12_analysis_dataset_1_12(_challenger_dataset([0.494, 2.6457]))
+    glo12._glo12_analysis_dataset_1_12(_challenger_dataset([0.494025, 2.645669]))
+    glo12._glo12_analysis_dataset_1_12(_challenger_dataset([0.494025, 47.37369]))
+
+    assert captured_variants[0][0] == "twelfth_degree"
+    assert captured_variants[0][1] == captured_variants[1][1]
+    assert captured_variants[0][1] != captured_variants[2][1]
+
+
+def test_weekly_stage_variant_is_added_to_stage_path_without_changing_resolution(monkeypatch) -> None:
+    monkeypatch.setattr("oceanbench.core.weekly_stage.local_stage_directory", lambda: Path("/tmp/oceanbench-stage"))
+
+    stage_directory = _weekly_stage_directory(
+        dataset_kind="reference",
+        dataset_name="glo12",
+        resolution="twelfth_degree",
+        stage_variant="depths-23-abc",
+        lead_days_count=10,
+    )
+
+    assert str(stage_directory) == "/tmp/oceanbench-stage/reference-glo12-twelfth_degree-depths-23-abc-10d"
+
+
+def test_weekly_stage_variant_is_preserved_in_non_staged_source_metadata(monkeypatch) -> None:
+    monkeypatch.setattr("oceanbench.core.weekly_stage.should_stage_locally", lambda _stage_key: False)
+
+    dataset = maybe_stage_weekly_dataset(
+        stage_key="references",
+        dataset_kind="reference",
+        dataset_name="glo12",
+        first_day_datetimes=numpy.array([numpy.datetime64("2024-01-03")]),
+        lead_days_count=10,
+        open_week_dataset=lambda _first_day_datetime: xarray.Dataset(),
+        open_remote_dataset=xarray.Dataset,
+        resolution="twelfth_degree",
+        stage_variant="depths-23-abc",
+    )
+
+    assert get_dataset_source(dataset) == DatasetSource(
+        kind="reference",
+        name="glo12",
+        resolution="twelfth_degree",
+        variant="depths-23-abc",
+    )
+
+
+def test_dataset_source_keeps_internal_variant_separate_from_resolution() -> None:
+    dataset = with_dataset_source(
+        xarray.Dataset(),
+        kind="reference",
+        name="glo12",
+        resolution="twelfth_degree",
+        variant="depths-23-abc",
+    )
+
+    dataset_source = get_dataset_source(dataset)
+
+    assert dataset_source == DatasetSource(
+        kind="reference",
+        name="glo12",
+        resolution="twelfth_degree",
+        variant="depths-23-abc",
+    )
+
+
+def test_lagrangian_stage_path_uses_source_variant(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "oceanbench.core.lagrangian_support.local_stage_directory", lambda: Path("/tmp/oceanbench-stage")
+    )
+
+    stage_directory = _lagrangian_stage_directory(
+        DatasetSource(
+            kind="reference",
+            name="glo12",
+            resolution="twelfth_degree",
+            variant="depths-23-abc",
+        ),
+        lead_days_count=10,
+    )
+
+    assert str(stage_directory) == "/tmp/oceanbench-stage/lagrangian-reference-glo12-twelfth_degree-depths-23-abc-10d"


### PR DESCRIPTION
fix: include a stable depth-grid fingerprint in the staged reference cache path, so each challenger reuses only references generated for its own vertical levels.