### PR TITLE
Parallelize website report discovery and download to fix Update website timeout

### DIFF
--- a/website/download_reports.py
+++ b/website/download_reports.py
@@ -3,8 +3,10 @@
 # SPDX-License-Identifier: EUPL-1.2
 
 import os
+from concurrent.futures import ThreadPoolExecutor
 
 from helpers.s3_discovery import (
+    MAXIMUM_PARALLEL_REQUESTS,
     available_versions,
     default_version,
     discover_downloaded_reports,
@@ -33,17 +35,24 @@ def _download_version_reports(version: str) -> bool:
     version_directory = os.path.join(REPORTS_DIRECTORY, version)
     published_reports = discover_official_reports(version)
     print(f"[{version}] discovered reports: {published_reports}")
-    downloaded_any_report = False
-    for region_id, challengers in published_reports.items():
-        for challenger_name in challengers:
-            print(f"Downloading {version}/{challenger_name}.{region_id}...", end=" ")
-            result = download_notebook(version, challenger_name, region_id, version_directory)
-            if not result:
-                print("FAILED")
-                raise RuntimeError(f"Failed to download notebook for {version}/{challenger_name}.{region_id}.")
-            print(f"OK -> {result}")
-            downloaded_any_report = True
-    return downloaded_any_report
+    pending_reports = [
+        (challenger_name, region_id)
+        for region_id, challenger_names in published_reports.items()
+        for challenger_name in challenger_names
+    ]
+
+    def download(report: tuple[str, str]) -> str | None:
+        challenger_name, region_id = report
+        return download_notebook(version, challenger_name, region_id, version_directory)
+
+    with ThreadPoolExecutor(max_workers=MAXIMUM_PARALLEL_REQUESTS) as pool:
+        downloaded_paths = list(pool.map(download, pending_reports))
+
+    for (challenger_name, region_id), downloaded_path in zip(pending_reports, downloaded_paths):
+        if not downloaded_path:
+            raise RuntimeError(f"Failed to download notebook for {version}/{challenger_name}.{region_id}.")
+        print(f"Downloaded {version}/{challenger_name}.{region_id} -> {downloaded_path}")
+    return bool(pending_reports)
 
 
 def main() -> None:

--- a/website/helpers/s3_discovery.py
+++ b/website/helpers/s3_discovery.py
@@ -4,6 +4,7 @@
 
 import os
 import re
+from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
@@ -13,6 +14,11 @@ S3_BASE_URL = "https://minio.dive.edito.eu/project-oceanbench"
 REPORTS_ROOT_PREFIX = "public/evaluation-reports"
 REPORT_INDEX_URL = f"{S3_BASE_URL}/{REPORTS_ROOT_PREFIX}/index.json"
 REPORT_FILE_PATTERN = re.compile(r"^(?P<challenger>.+)\.(?P<region>[a-z0-9_-]+)\.report\.ipynb$")
+
+# The report discovery and download steps each issue one HTTP request per challenger and region.
+# Running them concurrently keeps the website rebuild well under the gateway timeout as the number
+# of published versions grows.
+MAXIMUM_PARALLEL_REQUESTS = 16
 
 # index.json stored next to the reports is the single source of truth: editing it
 # (or uploading a new report) publishes a version or challenger without a library release.
@@ -67,11 +73,21 @@ def _report_exists(version: str, challenger_name: str, region_id: str) -> bool:
 
 
 def discover_official_reports(version: str) -> dict[str, list[str]]:
+    challenger_names = challengers_for_version(version)
+    probes = [
+        (challenger_name, region_id) for region_id in published_region_ids() for challenger_name in challenger_names
+    ]
+
+    def report_exists(probe: tuple[str, str]) -> bool:
+        challenger_name, region_id = probe
+        return _report_exists(version, challenger_name, region_id)
+
+    with ThreadPoolExecutor(max_workers=MAXIMUM_PARALLEL_REQUESTS) as pool:
+        available_probes = {probe for probe, exists in zip(probes, pool.map(report_exists, probes)) if exists}
+
     return {
         region_id: [
-            challenger_name
-            for challenger_name in challengers_for_version(version)
-            if _report_exists(version, challenger_name, region_id)
+            challenger_name for challenger_name in challenger_names if (challenger_name, region_id) in available_probes
         ]
         for region_id in published_region_ids()
     }


### PR DESCRIPTION
The **Update website** job `curl`s `/update`, which rebuilds the site synchronously. The rebuild downloads every report with one HTTP request per challenger × region, sequentially, for every version. As versions piled up (0.1.3 → 0.2.1) the serial round-trips crossed the gateway timeout → `curl: (56)` (failures on #286, #287).

Fix: run the discovery HEAD probes and downloads concurrently (bounded `ThreadPoolExecutor`, 16 workers). Same reports, just parallel I/O.

Measured on the live bucket: ~38 s → ~3 s network time.

Follow-ups (out of scope): make `/update` async server-side; optionally make the CI `curl` non-blocking.
