### PR TITLE
Make update-website curl fire-and-forget so CI doesn't fail on rebuild timeout

### DIFF
--- a/.github/workflows/update-website.yml
+++ b/.github/workflows/update-website.yml
@@ -14,4 +14,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: curl /update
-        run: curl https://oceanbench.lab.dive.edito.eu/update
+        run: curl -fsS --max-time 10 https://oceanbench.lab.dive.edito.eu/update || true


### PR DESCRIPTION
The `/update` endpoint triggers a synchronous site rebuild that outlasts the ~50s gateway idle timeout, so the curl is always cut off (exit 56) even though the rebuild completes server-side and the periodic task rebuilds regardless. Make the trigger best-effort (`--max-time 10 ... || true`) so the job reports 'rebuild requested' instead of failing on an unrelated timeout.