### PR TITLE
Version-less report redirects and shareable scores URLs

### DIFF
--- a/website/_quarto.yml
+++ b/website/_quarto.yml
@@ -5,6 +5,7 @@
 project:
   type: website
   pre-render: python download_reports.py
+  post-render: python generate_report_redirects.py
   resources:
     - assets/land-110m.json
 website:

--- a/website/build-website.sh
+++ b/website/build-website.sh
@@ -19,6 +19,7 @@ rm -rf reports _site
 pip install -r requirements.txt
 quarto render --to html
 
+rm -rf /app/repository
 mkdir -p /app/repository
 cp -r _site/* /app/repository
 

--- a/website/build-website.sh
+++ b/website/build-website.sh
@@ -19,8 +19,8 @@ rm -rf reports _site
 pip install -r requirements.txt
 quarto render --to html
 
-rm -rf /app/repository
 mkdir -p /app/repository
+rm -rf /app/repository/reports
 cp -r _site/* /app/repository
 
 popd > /dev/null

--- a/website/generate_report_redirects.py
+++ b/website/generate_report_redirects.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: 2025 Mercator Ocean International <https://www.mercator-ocean.eu/>
+#
+# SPDX-License-Identifier: EUPL-1.2
+
+import html
+import os
+
+from helpers.s3_discovery import _version_sort_key, default_version
+
+SCRIPT_DIRECTORY = os.path.dirname(__file__)
+
+
+def _output_directory() -> str:
+    configured_output_directory = os.environ.get("QUARTO_PROJECT_OUTPUT_DIR")
+    if configured_output_directory:
+        return os.path.abspath(configured_output_directory)
+    return os.path.join(SCRIPT_DIRECTORY, "_site")
+
+
+def _highest_rendered_version(reports_directory: str) -> str:
+    if not os.path.isdir(reports_directory):
+        return ""
+
+    version_names = [
+        file_name
+        for file_name in os.listdir(reports_directory)
+        if os.path.isdir(os.path.join(reports_directory, file_name))
+    ]
+    sorted_versions = sorted(version_names, key=_version_sort_key, reverse=True)
+    return sorted_versions[0] if sorted_versions else ""
+
+
+def _default_rendered_version(reports_directory: str) -> str:
+    try:
+        version = default_version()
+    except Exception as error:
+        print(f"Warning: could not discover default report version: {error}")
+        return _highest_rendered_version(reports_directory)
+
+    return version or _highest_rendered_version(reports_directory)
+
+
+def _report_file_names(version_directory: str) -> list[str]:
+    if not os.path.isdir(version_directory):
+        return []
+    return sorted(file_name for file_name in os.listdir(version_directory) if file_name.endswith(".report.html"))
+
+
+def _redirect_html(version: str, file_name: str) -> str:
+    redirect_url = f"./{version}/{file_name}"
+    escaped_redirect_url = html.escape(redirect_url, quote=True)
+    escaped_file_name = html.escape(file_name)
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="refresh" content="0; url={escaped_redirect_url}">
+  <link rel="canonical" href="{escaped_redirect_url}">
+  <title>Redirecting to {escaped_file_name}</title>
+  <script>location.replace("{escaped_redirect_url}");</script>
+</head>
+<body>
+  <p>Redirecting to the latest report…</p>
+</body>
+</html>
+"""
+
+
+def _write_redirect(reports_directory: str, version: str, file_name: str) -> None:
+    redirect_path = os.path.join(reports_directory, file_name)
+    with open(redirect_path, "w", encoding="utf-8") as file:
+        file.write(_redirect_html(version, file_name))
+
+
+def main() -> None:
+    output_directory = _output_directory()
+    reports_directory = os.path.join(output_directory, "reports")
+    version = _default_rendered_version(reports_directory)
+
+    if not version:
+        print(f"Warning: no rendered report version found under {reports_directory}.")
+        return
+
+    report_file_names = _report_file_names(os.path.join(reports_directory, version))
+    for file_name in report_file_names:
+        _write_redirect(reports_directory, version, file_name)
+
+    print(f"Wrote {len(report_file_names)} report redirect stubs for version {version}.")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/generate_report_redirects.py
+++ b/website/generate_report_redirects.py
@@ -5,44 +5,13 @@
 import html
 import os
 
-from helpers.s3_discovery import _version_sort_key, default_version
+from helpers.s3_discovery import default_version
 
-SCRIPT_DIRECTORY = os.path.dirname(__file__)
-
-
-def _output_directory() -> str:
-    configured_output_directory = os.environ.get("QUARTO_PROJECT_OUTPUT_DIR")
-    if configured_output_directory:
-        return os.path.abspath(configured_output_directory)
-    return os.path.join(SCRIPT_DIRECTORY, "_site")
-
-
-def _highest_rendered_version(reports_directory: str) -> str:
-    if not os.path.isdir(reports_directory):
-        return ""
-
-    version_names = [
-        file_name
-        for file_name in os.listdir(reports_directory)
-        if os.path.isdir(os.path.join(reports_directory, file_name))
-    ]
-    sorted_versions = sorted(version_names, key=_version_sort_key, reverse=True)
-    return sorted_versions[0] if sorted_versions else ""
-
-
-def _default_rendered_version(reports_directory: str) -> str:
-    try:
-        version = default_version()
-    except Exception as error:
-        print(f"Warning: could not discover default report version: {error}")
-        return _highest_rendered_version(reports_directory)
-
-    return version or _highest_rendered_version(reports_directory)
+OUTPUT_DIRECTORY = os.path.abspath(os.environ["QUARTO_PROJECT_OUTPUT_DIR"])
+REPORTS_DIRECTORY = os.path.join(OUTPUT_DIRECTORY, "reports")
 
 
 def _report_file_names(version_directory: str) -> list[str]:
-    if not os.path.isdir(version_directory):
-        return []
     return sorted(file_name for file_name in os.listdir(version_directory) if file_name.endswith(".report.html"))
 
 
@@ -66,25 +35,17 @@ def _redirect_html(version: str, file_name: str) -> str:
 """
 
 
-def _write_redirect(reports_directory: str, version: str, file_name: str) -> None:
-    redirect_path = os.path.join(reports_directory, file_name)
+def _write_redirect(version: str, file_name: str) -> None:
+    redirect_path = os.path.join(REPORTS_DIRECTORY, file_name)
     with open(redirect_path, "w", encoding="utf-8") as file:
         file.write(_redirect_html(version, file_name))
 
 
 def main() -> None:
-    output_directory = _output_directory()
-    reports_directory = os.path.join(output_directory, "reports")
-    version = _default_rendered_version(reports_directory)
-
-    if not version:
-        print(f"Warning: no rendered report version found under {reports_directory}.")
-        return
-
-    report_file_names = _report_file_names(os.path.join(reports_directory, version))
+    version = default_version()
+    report_file_names = _report_file_names(os.path.join(REPORTS_DIRECTORY, version))
     for file_name in report_file_names:
-        _write_redirect(reports_directory, version, file_name)
-
+        _write_redirect(version, file_name)
     print(f"Wrote {len(report_file_names)} report redirect stubs for version {version}.")
 
 

--- a/website/interactive-scores.js
+++ b/website/interactive-scores.js
@@ -54,6 +54,21 @@ let activeRegion = null;
 let activeVersion = null;
 let isScrollRefreshScheduled = false;
 
+const URL_STATE_PARAMETERS = {
+  version: "version",
+  region: "region",
+  track: "track",
+  baseline: "baseline",
+  display: "display",
+  depths: "depths",
+  scale: "scale",
+};
+
+let selectedBaseline = null;
+let defaultVersionValue = null;
+let defaultRegionValue = null;
+let defaultBaselineValue = null;
+
 const SECTION_ORDER = ["observations", "reanalysis", "analysis"];
 
 const SECTION_ID_MAP = {
@@ -1197,7 +1212,7 @@ function renderTablesOnly() {
   if (visibleChallengerNames.length === 0) return;
 
   const existingSelect = document.getElementById("baseline-select");
-  const baseline = resolveBaselineSelectionForTrack(visibleChallengerNames, existingSelect?.value);
+  const baseline = resolveBaselineSelectionForTrack(visibleChallengerNames, existingSelect?.value ?? selectedBaseline);
   if (!baseline) return;
 
   for (const [sectionKey, sectionConfig] of Object.entries(sections)) {
@@ -1217,6 +1232,9 @@ function renderTablesOnly() {
 
   updateColorLegend();
   setupCellHighlight();
+
+  selectedBaseline = baseline;
+  writeUrlState();
 }
 
 function renderAllTables() {
@@ -1232,7 +1250,7 @@ function renderAllTables() {
   if (visibleChallengerNames.length === 0) return;
 
   const existingSelect = document.getElementById("baseline-select");
-  const baseline = resolveBaselineSelectionForTrack(visibleChallengerNames, existingSelect?.value);
+  const baseline = resolveBaselineSelectionForTrack(visibleChallengerNames, existingSelect?.value ?? selectedBaseline);
   if (!baseline) return;
   const availableDepths = getAvailableDepths(challengers, baseline, sections);
 
@@ -1271,6 +1289,85 @@ function renderAllTables() {
   setActiveSection(activeSection);
   refreshScrollSpy();
   setupCellHighlight();
+
+  const versions = getVersions(data);
+  defaultVersionValue = versions.includes(data.default_version) ? data.default_version : versions[0] || null;
+  defaultRegionValue = regionIds[0] || null;
+  defaultBaselineValue = resolveBaselineSelectionForTrack(visibleChallengerNames, null);
+  selectedBaseline = baseline;
+  writeUrlState();
+}
+
+function applyUrlStateFromLocation() {
+  const parameters = new URLSearchParams(window.location.search);
+
+  const versionParameter = parameters.get(URL_STATE_PARAMETERS.version);
+  if (versionParameter) activeVersion = versionParameter;
+
+  const regionParameter = parameters.get(URL_STATE_PARAMETERS.region);
+  if (regionParameter) activeRegion = regionParameter;
+
+  const trackParameter = parameters.get(URL_STATE_PARAMETERS.track);
+  if (trackParameter) activeTrack = trackParameter;
+
+  const baselineParameter = parameters.get(URL_STATE_PARAMETERS.baseline);
+  if (baselineParameter) selectedBaseline = baselineParameter;
+
+  const displayParameter = parameters.get(URL_STATE_PARAMETERS.display);
+  if (displayParameter) showPercentDiff = displayParameter === "percent";
+
+  const depthsParameter = parameters.get(URL_STATE_PARAMETERS.depths);
+  if (depthsParameter) {
+    if (depthsParameter === "all") {
+      showAllMode = true;
+      selectedDepths = new Set();
+    } else {
+      showAllMode = false;
+      selectedDepths = new Set(depthsParameter.split(",").filter((depth) => depth !== ""));
+    }
+  }
+
+  const scaleParameter = parameters.get(URL_STATE_PARAMETERS.scale);
+  if (scaleParameter) {
+    const parsedScale = Number(scaleParameter);
+    if (isFinite(parsedScale) && parsedScale > 0) {
+      maxScale = parsedScale;
+      colorScaleEdges = buildBinEdges(maxScale);
+    }
+  }
+}
+
+function writeUrlState() {
+  if (!parsedData) return;
+  const parameters = new URLSearchParams();
+
+  if (activeVersion && activeVersion !== defaultVersionValue) {
+    parameters.set(URL_STATE_PARAMETERS.version, activeVersion);
+  }
+  if (activeRegion && activeRegion !== defaultRegionValue) {
+    parameters.set(URL_STATE_PARAMETERS.region, activeRegion);
+  }
+  if (activeTrack && activeTrack !== "high_resolution") {
+    parameters.set(URL_STATE_PARAMETERS.track, activeTrack);
+  }
+  if (selectedBaseline && selectedBaseline !== defaultBaselineValue) {
+    parameters.set(URL_STATE_PARAMETERS.baseline, selectedBaseline);
+  }
+  if (showPercentDiff) {
+    parameters.set(URL_STATE_PARAMETERS.display, "percent");
+  }
+  if (!showAllMode && selectedDepths.size > 0) {
+    const orderedDepths = [...selectedDepths].sort((first, second) => Number(first) - Number(second));
+    parameters.set(URL_STATE_PARAMETERS.depths, orderedDepths.join(","));
+  }
+  if (maxScale !== 80) {
+    parameters.set(URL_STATE_PARAMETERS.scale, `${maxScale}`);
+  }
+
+  const queryString = parameters.toString();
+  const newRelativeUrl =
+    window.location.pathname + (queryString ? `?${queryString}` : "") + window.location.hash;
+  window.history.replaceState(null, "", newRelativeUrl);
 }
 
 function init() {
@@ -1279,6 +1376,7 @@ function init() {
   if (initialSection) {
     activeSection = initialSection;
   }
+  applyUrlStateFromLocation();
   renderAllTables();
 
   if (initialSection) {

--- a/website/interactive-scores.js
+++ b/website/interactive-scores.js
@@ -54,16 +54,6 @@ let activeRegion = null;
 let activeVersion = null;
 let isScrollRefreshScheduled = false;
 
-const URL_STATE_PARAMETERS = {
-  version: "version",
-  region: "region",
-  track: "track",
-  baseline: "baseline",
-  display: "display",
-  depths: "depths",
-  scale: "scale",
-};
-
 let selectedBaseline = null;
 let defaultVersionValue = null;
 let defaultRegionValue = null;
@@ -1122,9 +1112,7 @@ function ensureParsedData() {
     parsedData = JSON.parse(dataElement.textContent);
     const versions = getVersions(parsedData);
     if (!activeVersion || !versions.includes(activeVersion)) {
-      activeVersion = versions.includes(parsedData.default_version)
-        ? parsedData.default_version
-        : versions[0] || null;
+      activeVersion = resolveDefaultVersion(parsedData);
     }
     applyActiveVersion();
   }
@@ -1133,6 +1121,11 @@ function ensureParsedData() {
 
 function getVersions(data) {
   return data.version_order || Object.keys(data.versions || {});
+}
+
+function resolveDefaultVersion(data) {
+  const versions = getVersions(data);
+  return versions.includes(data.default_version) ? data.default_version : versions[0] || null;
 }
 
 function getActiveVersionData(data) {
@@ -1290,8 +1283,7 @@ function renderAllTables() {
   refreshScrollSpy();
   setupCellHighlight();
 
-  const versions = getVersions(data);
-  defaultVersionValue = versions.includes(data.default_version) ? data.default_version : versions[0] || null;
+  defaultVersionValue = resolveDefaultVersion(data);
   defaultRegionValue = regionIds[0] || null;
   defaultBaselineValue = resolveBaselineSelectionForTrack(visibleChallengerNames, null);
   selectedBaseline = baseline;
@@ -1301,22 +1293,22 @@ function renderAllTables() {
 function applyUrlStateFromLocation() {
   const parameters = new URLSearchParams(window.location.search);
 
-  const versionParameter = parameters.get(URL_STATE_PARAMETERS.version);
+  const versionParameter = parameters.get("version");
   if (versionParameter) activeVersion = versionParameter;
 
-  const regionParameter = parameters.get(URL_STATE_PARAMETERS.region);
+  const regionParameter = parameters.get("region");
   if (regionParameter) activeRegion = regionParameter;
 
-  const trackParameter = parameters.get(URL_STATE_PARAMETERS.track);
+  const trackParameter = parameters.get("track");
   if (trackParameter) activeTrack = trackParameter;
 
-  const baselineParameter = parameters.get(URL_STATE_PARAMETERS.baseline);
+  const baselineParameter = parameters.get("baseline");
   if (baselineParameter) selectedBaseline = baselineParameter;
 
-  const displayParameter = parameters.get(URL_STATE_PARAMETERS.display);
+  const displayParameter = parameters.get("display");
   if (displayParameter) showPercentDiff = displayParameter === "percent";
 
-  const depthsParameter = parameters.get(URL_STATE_PARAMETERS.depths);
+  const depthsParameter = parameters.get("depths");
   if (depthsParameter) {
     if (depthsParameter === "all") {
       showAllMode = true;
@@ -1327,7 +1319,7 @@ function applyUrlStateFromLocation() {
     }
   }
 
-  const scaleParameter = parameters.get(URL_STATE_PARAMETERS.scale);
+  const scaleParameter = parameters.get("scale");
   if (scaleParameter) {
     const parsedScale = Number(scaleParameter);
     if (isFinite(parsedScale) && parsedScale > 0) {
@@ -1342,26 +1334,26 @@ function writeUrlState() {
   const parameters = new URLSearchParams();
 
   if (activeVersion && activeVersion !== defaultVersionValue) {
-    parameters.set(URL_STATE_PARAMETERS.version, activeVersion);
+    parameters.set("version", activeVersion);
   }
   if (activeRegion && activeRegion !== defaultRegionValue) {
-    parameters.set(URL_STATE_PARAMETERS.region, activeRegion);
+    parameters.set("region", activeRegion);
   }
   if (activeTrack && activeTrack !== "high_resolution") {
-    parameters.set(URL_STATE_PARAMETERS.track, activeTrack);
+    parameters.set("track", activeTrack);
   }
   if (selectedBaseline && selectedBaseline !== defaultBaselineValue) {
-    parameters.set(URL_STATE_PARAMETERS.baseline, selectedBaseline);
+    parameters.set("baseline", selectedBaseline);
   }
   if (showPercentDiff) {
-    parameters.set(URL_STATE_PARAMETERS.display, "percent");
+    parameters.set("display", "percent");
   }
   if (!showAllMode && selectedDepths.size > 0) {
     const orderedDepths = [...selectedDepths].sort((first, second) => Number(first) - Number(second));
-    parameters.set(URL_STATE_PARAMETERS.depths, orderedDepths.join(","));
+    parameters.set("depths", orderedDepths.join(","));
   }
   if (maxScale !== 80) {
-    parameters.set(URL_STATE_PARAMETERS.scale, `${maxScale}`);
+    parameters.set("scale", `${maxScale}`);
   }
 
   const queryString = parameters.toString();


### PR DESCRIPTION
- **Version-less report links**: publish a redirect stub per latest-version report so `reports/<model>.<region>.report.html` (no version segment) resolves to the current version, and purge the deployed `reports/` output so stale files stop lingering.
- **Shareable scores URLs**: encode the scores UI state (version, region, track, baseline, display mode, depth selection, colour scale) in the query string, applied on load and updated in place on each control change (omitting defaults). The section stays in the URL hash as before.